### PR TITLE
SECURITY: removed all http-method elements

### DIFF
--- a/lightblue-rest/crud-basic-auth/src/main/webapp/WEB-INF/web.xml
+++ b/lightblue-rest/crud-basic-auth/src/main/webapp/WEB-INF/web.xml
@@ -13,10 +13,6 @@
             <description>application security constraints
             </description>
             <url-pattern>/*</url-pattern>
-            <http-method>GET</http-method>
-            <http-method>POST</http-method>
-            <http-method>PUT</http-method>
-            <http-method>DELETE</http-method>
         </web-resource-collection>
         <auth-constraint>
             <role-name>lightblue-user</role-name>

--- a/lightblue-rest/crud/src/main/webapp/WEB-INF/web.xml
+++ b/lightblue-rest/crud/src/main/webapp/WEB-INF/web.xml
@@ -13,10 +13,6 @@
             <description>application security constraints
             </description>
             <url-pattern>/*</url-pattern>
-            <http-method>GET</http-method>
-            <http-method>POST</http-method>
-            <http-method>PUT</http-method>
-            <http-method>DELETE</http-method>
         </web-resource-collection>
         <auth-constraint>
             <role-name>lightblue-user</role-name>


### PR DESCRIPTION
 The HEAD method was not specified, which would lead to an authentication bypass similar to CVE-2010-0738. With no http-method elements, all methods are secured automatically.
