### PR TITLE
hystrix stream fix

### DIFF
--- a/lightblue-core/pom.xml
+++ b/lightblue-core/pom.xml
@@ -91,17 +91,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-core</artifactId>
-                <version>1.3.9</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-metrics-event-stream</artifactId>
-                <version>1.1.2</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-servo-metrics-publisher</artifactId>
-                <version>1.1.2</version>
+                <version>1.3.16</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/lightblue-mongo/pom.xml
+++ b/lightblue-mongo/pom.xml
@@ -98,17 +98,17 @@
            <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-core</artifactId>
-                <version>1.3.9</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-metrics-event-stream</artifactId>
-                <version>1.1.2</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-servo-metrics-publisher</artifactId>
-                <version>1.1.2</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/lightblue-rest/pom.xml
+++ b/lightblue-rest/pom.xml
@@ -42,17 +42,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-core</artifactId>
-                <version>1.3.9</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-metrics-event-stream</artifactId>
-                <version>1.1.2</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-servo-metrics-publisher</artifactId>
-                <version>1.1.2</version>
+                <version>1.3.16</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
dependencies hystrix-metrics-event-stream and
hystrix-servo-metrics-publisher need to be on the same version as
hystrix-core (updated to 1.3.16)
