### PR TITLE
Fixes #149: response always returns array of results

### DIFF
--- a/core-api/src/test/java/com/redhat/lightblue/ResponseTest.java
+++ b/core-api/src/test/java/com/redhat/lightblue/ResponseTest.java
@@ -18,17 +18,6 @@
  */
 package com.redhat.lightblue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -36,6 +25,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.lightblue.Response.ResponseBuilder;
 import com.redhat.lightblue.util.Error;
 import com.redhat.lightblue.util.JsonObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class ResponseTest {
 
@@ -46,8 +43,9 @@ public class ResponseTest {
 
     @Before
     public void setUp() throws Exception {
-        response = new Response();
-        builder = new Response.ResponseBuilder();
+        JsonNodeFactory jnf = JsonNodeFactory.withExactBigDecimals(true);
+        response = new Response(jnf);
+        builder = new Response.ResponseBuilder(jnf);
     }
 
     @After
@@ -122,9 +120,21 @@ public class ResponseTest {
     }
 
     @Test
-    public void testWithEntityData() {
+    public void testWithEntityDataObject() {
         node = JsonNodeFactory.withExactBigDecimals(true).objectNode();
         builder.withEntityData(node);
+        // note, entityData is treated as an array always.  in this case we have to extract the first element of the array for validation
+        assertTrue(node.equals(builder.buildResponse().getEntityData().get(0)));
+    }
+
+    @Test
+    public void testWithEntityDataArray() {
+        node = JsonNodeFactory.withExactBigDecimals(true).arrayNode();
+        ArrayNode anode = (ArrayNode) node;
+        anode.add(anode.objectNode());
+        anode.add(anode.objectNode());
+        builder.withEntityData(node);
+        assertEquals(2, builder.buildResponse().getEntityData().size());
         assertTrue(node.equals(builder.buildResponse().getEntityData()));
     }
 

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -83,7 +83,7 @@ public class Mediator {
     public Response insert(InsertionRequest req) {
         LOGGER.debug("insert {}", req.getEntityVersion());
         Error.push("insert(" + req.getEntityVersion().toString() + ")");
-        Response response = new Response();
+        Response response = new Response(factory.getNodeFactory());
         try {
             OperationContext ctx = OperationContext.getInstance(req, metadata, factory, Operation.INSERT);
             EntityMetadata md = ctx.getTopLevelEntityMetadata();
@@ -149,7 +149,7 @@ public class Mediator {
     public Response save(SaveRequest req) {
         LOGGER.debug("save {}", req.getEntityVersion());
         Error.push("save(" + req.getEntityVersion().toString() + ")");
-        Response response = new Response();
+        Response response = new Response(factory.getNodeFactory());
         try {
             OperationContext ctx = OperationContext.getInstance(req, metadata, factory, Operation.SAVE);
             EntityMetadata md = ctx.getTopLevelEntityMetadata();
@@ -215,7 +215,7 @@ public class Mediator {
     public Response update(UpdateRequest req) {
         LOGGER.debug("update {}", req.getEntityVersion());
         Error.push("update(" + req.getEntityVersion().toString() + ")");
-        Response response = new Response();
+        Response response = new Response(factory.getNodeFactory());
         try {
             OperationContext ctx = OperationContext.getInstance(req, metadata, factory, Operation.UPDATE);
             EntityMetadata md = ctx.getTopLevelEntityMetadata();
@@ -264,7 +264,7 @@ public class Mediator {
     public Response delete(DeleteRequest req) {
         LOGGER.debug("delete {}", req.getEntityVersion());
         Error.push("delete(" + req.getEntityVersion().toString() + ")");
-        Response response = new Response();
+        Response response = new Response(factory.getNodeFactory());
         try {
             OperationContext ctx = OperationContext.getInstance(req, metadata, factory, Operation.DELETE);
             EntityMetadata md = ctx.getTopLevelEntityMetadata();
@@ -313,7 +313,7 @@ public class Mediator {
     public Response find(FindRequest req) {
         LOGGER.debug("find {}", req.getEntityVersion());
         Error.push("find(" + req.getEntityVersion().toString() + ")");
-        Response response = new Response();
+        Response response = new Response(factory.getNodeFactory());
         response.setStatus(OperationStatus.ERROR);
         try {
             OperationContext ctx = OperationContext.getInstance(req, metadata, factory, Operation.FIND);

--- a/crud/src/main/resources/json-schema/response.json
+++ b/crud/src/main/resources/json-schema/response.json
@@ -42,7 +42,7 @@
             "additionalProperties": true,
             "description": "Session information for the client. How this is used is implementation dependent, and TBD"
         },
-        "response": {
+        "processed": {
             "type": "array",
             "items": {
                 "type": "object",

--- a/crud/src/test/resources/crud/response/schema-test-response-simple.json
+++ b/crud/src/test/resources/crud/response/schema-test-response-simple.json
@@ -6,7 +6,7 @@
     "session": {
         "content": "TBD"
     },
-    "response": [
+    "processed": [
         {
             "foo": "bar"
         }


### PR DESCRIPTION
- response checks if data is an array, if not wraps in an ArrayNode
- unit tests fixed
- mediator updated to pass JsonNodeFactory
- response.json updated to s/response/processed/ and reflects what is in code no
