### PR TITLE
Removed use of get(int) where possible

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/AbstractMetadataConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/AbstractMetadataConfiguration.java
@@ -103,8 +103,9 @@ public abstract class AbstractMetadataConfiguration implements MetadataConfigura
 
             ArrayNode backendParsersJs = (ArrayNode) node.get("backendParsers");
             if(backendParsersJs != null) {
-                for (int i = 0; i < backendParsersJs.size(); i++) {
-                    JsonNode jsonNode = backendParsersJs.get(i);
+                Iterator<JsonNode> bpjsItr = backendParsersJs.iterator();
+                while (bpjsItr.hasNext()) {
+                    JsonNode jsonNode = bpjsItr.next();
                     String name = jsonNode.get("name").asText();
                     String clazz = jsonNode.get("clazz").asText();
 
@@ -124,8 +125,7 @@ public abstract class AbstractMetadataConfiguration implements MetadataConfigura
 
             ArrayNode propertyParserJs = (ArrayNode) node.get("propertyParsers");
             if(propertyParserJs != null) {
-                for (int i = 0; i < propertyParserJs.size(); i++) {
-                    JsonNode jsonNode = propertyParserJs.get(i);
+                for (JsonNode jsonNode:propertyParserJs) {
                     String name = jsonNode.get("name").asText();
                     String clazz = jsonNode.get("clazz").asText();
 
@@ -157,8 +157,7 @@ public abstract class AbstractMetadataConfiguration implements MetadataConfigura
                     }
 
                     roleMap.put(name, new ArrayList<String>());
-                    for (int j = 0; j < rolesJs.size(); j++) {
-                        JsonNode jsonNode = rolesJs.get(j);
+                    for (JsonNode jsonNode: rolesJs) {
                         roleMap.get(name).add(jsonNode.textValue());
                     }
                 }

--- a/crud/src/main/java/com/redhat/lightblue/eval/ListProjector.java
+++ b/crud/src/main/java/com/redhat/lightblue/eval/ListProjector.java
@@ -20,6 +20,7 @@ package com.redhat.lightblue.eval;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.ListIterator;
 
 import com.redhat.lightblue.util.Path;
 
@@ -65,11 +66,13 @@ public class ListProjector extends Projector {
     public Boolean project(Path p, QueryEvaluationContext ctx) {
         nestedProjector = null;
         decidingProjector=null;
-        for (int n = items.size() - 1; n >= 0; n--) {
-            Boolean projectionResult = items.get(n).project(p, ctx);
+        ListIterator<Projector> itemsItr=items.listIterator(items.size());
+        while (itemsItr.hasPrevious()) {
+            Projector projector = itemsItr.previous();
+            Boolean projectionResult = projector.project(p, ctx);
             if (projectionResult != null) {
-                nestedProjector = items.get(n).getNestedProjector();
-                decidingProjector = items.get(n).getDecidingProjector();
+                nestedProjector = projector.getNestedProjector();
+                decidingProjector = projector.getDecidingProjector();
                 return projectionResult;
             }
         }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/CompositeMetadata.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/CompositeMetadata.java
@@ -217,9 +217,9 @@ public class CompositeMetadata extends EntityMetadata {
             FieldTreeNode trc = fieldNode;
             do {
                 if (trc instanceof ArrayElement && trc.getParent() instanceof ResolvedReferenceField) {
-                    int n = list.size();
-                    for (int i = n - 1; i >= 0; i--) {
-                        mp.push(list.get(i));
+                    ListIterator<String> listItr = list.listIterator(list.size());
+                    while (listItr.hasPrevious()) {
+                        mp.push(listItr.previous());
                     }
                     return mp.immutableCopy();
                 } else if (trc != getEntitySchema().getFieldTreeRoot()) {

--- a/query-api/src/main/java/com/redhat/lightblue/query/Projection.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/Projection.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.ListIterator;
 
 /**
  * Base class for all projection objects
@@ -300,8 +301,9 @@ public abstract class Projection extends JsonObject {
         LOGGER.debug("Checking if a projection list projects {}", field);
         Inclusion lastResult = Inclusion.undecided;
         List<Projection> items=p.getItems();
-        for(int i=items.size()-1;i>=0;i--) {
-            Inclusion ret = items.get(i).getFieldInclusion(field, context);
+        ListIterator<Projection> itemsItr = items.listIterator(items.size());
+        while (itemsItr.hasPrevious()) {
+            Inclusion ret = itemsItr.previous().getFieldInclusion(field, context);
             if (ret != Inclusion.undecided) {
                 lastResult=ret;
                 break;

--- a/util/src/main/java/com/redhat/lightblue/util/Path.java
+++ b/util/src/main/java/com/redhat/lightblue/util/Path.java
@@ -293,11 +293,12 @@ public class Path implements Comparable<Path>, Serializable {
      * @return true if it matches, else false
      */
     public boolean matches(Path pattern) {
-        int n = data.size();
-        if (n == pattern.data.size()) {
-            for (int i = 0; i < n; i++) {
-                String pat = pattern.data.get(i);
-                String val = data.get(i);
+        if (data.size() == pattern.data.size()) {
+            Iterator<String> patternDataItr = pattern.data.iterator();
+            Iterator<String> dataItr = data.iterator();
+            while (patternDataItr.hasNext() && dataItr.hasNext()) {
+                String pat = patternDataItr.next();
+                String val = dataItr.next();
                 if (!(val.equals(pat) || pat.equals(ANY))) {
                     return false;
                 }
@@ -349,8 +350,9 @@ public class Path implements Comparable<Path>, Serializable {
     public Path normalize() {
         int n = data.size();
         boolean parentThisPresent = false;
-        for (int i = 0; i < n; i++) {
-            String s = data.get(i);
+        Iterator<String> dataItr = data.iterator();
+        while (dataItr.hasNext()) {
+            String s = dataItr.next();
             if (PARENT.equals(s) || THIS.equals(s)) {
                 parentThisPresent = true;
                 break;
@@ -358,8 +360,9 @@ public class Path implements Comparable<Path>, Serializable {
         }
         if (parentThisPresent) {
             MutablePath p = new MutablePath();
-            for (int i = 0; i < n; i++) {
-                String s = data.get(i);
+            dataItr = data.iterator();
+            while (dataItr.hasNext()) {
+                String s = dataItr.next();
                 if (PARENT.equals(s)) {
                     p.pop();
                 } else if (!THIS.equals(s)) {
@@ -396,7 +399,6 @@ public class Path implements Comparable<Path>, Serializable {
      * argument.
      *
      * @param x the new paths segments to parse
-     * @param segments the segment list to append new segments onto
      */
     protected static List<String> parse(String x) {
         List<String> segments = new ArrayList<>();

--- a/util/src/main/java/com/redhat/lightblue/util/PathRep.java
+++ b/util/src/main/java/com/redhat/lightblue/util/PathRep.java
@@ -66,8 +66,11 @@ class PathRep implements Serializable, Comparable<PathRep> {
         } else {
             n = k + x;
         }
-        for (int i = 0; i < n; i++) {
-            segments.add(data.segments.get(i));
+        for (String s: data.segments) {
+            if (n <= 0)
+                break;
+            segments.add(s);
+            n--;
         }
     }
 


### PR DESCRIPTION
Found several places in reviewing association where get on lists was used.  This can be done much better with iterators.  Found `ListIterator` which allows for previous iteration as well to solve for cases when it has to be in reverse order.
