### PR TITLE
Allow description on fields in metadata json schema

### DIFF
--- a/metadata/src/main/resources/json-schema/metadata/schema.json
+++ b/metadata/src/main/resources/json-schema/metadata/schema.json
@@ -182,6 +182,9 @@
                                 },
                                 "access": {
                                     "$ref": "#/definitions/accessField"
+                                },
+                                "description": {
+                                    "type": "string"
                                 }
                             },
                             "additionalProperties": false,
@@ -203,6 +206,9 @@
                                 },
                                 "fields": {
                                     "$ref": "#/definitions/fieldSingle"
+                                },
+                                "description": {
+                                    "type": "string"
                                 }
                             },
                             "additionalProperties": false,
@@ -222,6 +228,9 @@
                                 },
                                 "access": {
                                     "$ref": "#/definitions/accessField"
+                                },
+                                "description": {
+                                    "type": "string"
                                 },
                                 "items": {
                                     "oneOf": [


### PR DESCRIPTION
This is causing audit metadata in audit-hook to fail validation.
