### PR TITLE
Change ServoGraphiteSetup to ignore if a metric publisher already exists

### DIFF
--- a/util/src/main/java/com/redhat/lightblue/util/ServoGraphiteSetup.java
+++ b/util/src/main/java/com/redhat/lightblue/util/ServoGraphiteSetup.java
@@ -18,12 +18,20 @@
  */
 package com.redhat.lightblue.util;
 
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.netflix.hystrix.contrib.servopublisher.HystrixServoMetricsPublisher;
 import com.netflix.hystrix.strategy.HystrixPlugins;
-import com.netflix.servo.publish.*;
+import com.netflix.servo.publish.BasicMetricFilter;
+import com.netflix.servo.publish.JvmMetricPoller;
+import com.netflix.servo.publish.MetricObserver;
+import com.netflix.servo.publish.MonitorRegistryMetricPoller;
+import com.netflix.servo.publish.PollRunnable;
+import com.netflix.servo.publish.PollScheduler;
 import com.netflix.servo.publish.graphite.GraphiteMetricObserver;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * Utility class for publishing hystrix and jvm stats from servo to graphite. If
@@ -33,6 +41,8 @@ import java.util.concurrent.TimeUnit;
  * @author nmalik
  */
 public final class ServoGraphiteSetup {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServoGraphiteSetup.class);
+
     private static boolean initialized = false;
 
     private ServoGraphiteSetup() {
@@ -65,7 +75,12 @@ public final class ServoGraphiteSetup {
         }
 
         // register hystrix servo metrics publisher
-        HystrixPlugins.getInstance().registerMetricsPublisher(HystrixServoMetricsPublisher.getInstance());
+        try{
+            HystrixPlugins.getInstance().registerMetricsPublisher(HystrixServoMetricsPublisher.getInstance());
+        }
+        catch(IllegalStateException e){
+            LOGGER.warn("A metrics publisher has already been registerd, ignoring this step and using the existing publisher", e);
+        }
 
         // try to get name from openshift.  assume it's scaleable app.
         // format: <app name>.  <namespace>.<gear dns>
@@ -78,7 +93,7 @@ public final class ServoGraphiteSetup {
                     System.getenv("OPENSHIFT_APP_NAME"),
                     System.getenv("OPENSHIFT_NAMESPACE"),
                     System.getenv("OPENSHIFT_GEAR_DNS")
-            );
+                    );
         }
 
         String host = System.getenv("GRAPHITE_HOSTNAME");
@@ -90,14 +105,14 @@ public final class ServoGraphiteSetup {
         String addr = host + ":" + port;
         MetricObserver observer = new GraphiteMetricObserver(prefix, addr);
 
-        // start poll scheduler  
+        // start poll scheduler
         PollScheduler.getInstance().start();
 
-        // create and register registery poller  
+        // create and register registery poller
         PollRunnable registeryTask = new PollRunnable(new MonitorRegistryMetricPoller(), BasicMetricFilter.MATCH_ALL, observer);
         PollScheduler.getInstance().addPoller(registeryTask, 5, TimeUnit.SECONDS);
 
-        // create and register jvm poller  
+        // create and register jvm poller
         PollRunnable jvmTask = new PollRunnable(new JvmMetricPoller(), BasicMetricFilter.MATCH_ALL, observer);
         PollScheduler.getInstance().addPoller(jvmTask, 5, TimeUnit.SECONDS);
 


### PR DESCRIPTION
Fixes this exception that I was gettting.

com.redhat.lightblue.rest.metadata.RestApplication threw exception: java.lang.IllegalStateException: Another strategy was already registered.
        at com.netflix.hystrix.strategy.HystrixPlugins.registerMetricsPublisher(HystrixPlugins.java:180)
        at com.redhat.lightblue.util.ServoGraphiteSetup.doInitialize(ServoGraphiteSetup.java:72)
        at com.redhat.lightblue.util.ServoGraphiteSetup.initialize(ServoGraphiteSetup.java:62)
        at com.redhat.lightblue.rest.metadata.MetadataResource.<clinit>(MetadataResource.java:31)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
        at org.jboss.resteasy.core.ConstructorInjectorImpl.construct(ConstructorInjectorImpl.java:82)
        at org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory.createResource(POJOResourceFactory.java:43)
        at org.jboss.resteasy.core.ResourceMethod.invoke(ResourceMethod.java:215)
        at org.jboss.resteasy.core.SynchronousDispatcher.getResponse(SynchronousDispatcher.java:542)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:524)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:126)
        at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:208)
        at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55)
        at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:50)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:847)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:295)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:230)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:149)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:481)
        at org.jboss.as.web.security.SecurityContextAssociationValve.invoke(SecurityContextAssociationValve.java:169)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:145)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:97)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:102)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:336)
        at org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:856)
        at org.apache.coyote.http11.Http11Protocol$Http11ConnectionHandler.process(Http11Protocol.java:653)
        at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:508)
        at org.jboss.threads.SimpleDirectExecutor.execute(SimpleDirectExecutor.java:33)
        at org.jboss.threads.QueueExecutor.runTask(QueueExecutor.java:806)
        at org.jboss.threads.QueueExecutor.access$100(QueueExecutor.java:45)
        at org.jboss.threads.QueueExecutor$Worker.run(QueueExecutor.java:826)
        at java.lang.Thread.run(Thread.java:745)
        at org.jboss.threads.JBossThread.run(JBossThread.java:122)
