### PR TITLE
DataSourceConfiguration can now return a specific type of DataSource

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/DataSourceConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/DataSourceConfiguration.java
@@ -18,10 +18,10 @@
  */
 package com.redhat.lightblue.config;
 
-import com.redhat.lightblue.util.JsonInitializable;
+import java.io.Serializable;
 
 import com.redhat.lightblue.metadata.parser.DataStoreParser;
-import java.io.Serializable;
+import com.redhat.lightblue.util.JsonInitializable;
 
 /**
  * Base interface for backend configuration
@@ -31,6 +31,6 @@ public interface DataSourceConfiguration extends JsonInitializable, Serializable
     /**
      * Returns the metadata backend parser class
      */
-    Class<DataStoreParser> getMetadataDataStoreParser();
+    Class<? extends DataStoreParser> getMetadataDataStoreParser();
 
 }

--- a/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
+++ b/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
@@ -18,23 +18,32 @@
  */
 package com.redhat.lightblue.config;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.lightblue.Request;
 import com.redhat.lightblue.crud.CRUDController;
 import com.redhat.lightblue.crud.CrudConstants;
-import com.redhat.lightblue.crud.Factory;
 import com.redhat.lightblue.crud.DeleteRequest;
+import com.redhat.lightblue.crud.Factory;
+import com.redhat.lightblue.crud.FindRequest;
 import com.redhat.lightblue.crud.InsertionRequest;
 import com.redhat.lightblue.crud.SaveRequest;
 import com.redhat.lightblue.crud.UpdateRequest;
-import com.redhat.lightblue.crud.FindRequest;
 import com.redhat.lightblue.crud.interceptors.UIDInterceptor;
 import com.redhat.lightblue.crud.validator.DefaultFieldConstraintValidators;
 import com.redhat.lightblue.mediator.Mediator;
-import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.EntityInfo;
+import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.EntitySchema;
 import com.redhat.lightblue.metadata.Metadata;
 import com.redhat.lightblue.metadata.MetadataConstants;
@@ -43,14 +52,6 @@ import com.redhat.lightblue.metadata.parser.Extensions;
 import com.redhat.lightblue.metadata.parser.JSONMetadataParser;
 import com.redhat.lightblue.metadata.types.DefaultTypes;
 import com.redhat.lightblue.util.JsonUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 /**
  * Manager class that creates instances of Mediator, Factory, Metadata, etc.
@@ -84,7 +85,7 @@ public final class LightblueFactory implements Serializable {
 
             Map<String, DataSourceConfiguration> ds = datasources.getDataSources();
             for (Map.Entry<String, DataSourceConfiguration> entry : ds.entrySet()) {
-                Class<DataStoreParser> tempParser = entry.getValue().getMetadataDataStoreParser();
+                Class<? extends DataStoreParser> tempParser = entry.getValue().getMetadataDataStoreParser();
                 DataStoreParser backendParser = tempParser.newInstance();
                 extensions.registerDataStoreParser(backendParser.getDefaultName(), backendParser);
             }


### PR DESCRIPTION
Allows getMetadataDataStoreParser implementations to return any type of DataStoreParser, without having to do odd casts.
