### PR TITLE
Fixes #199: Removes the need to strings in role hash

### DIFF
--- a/config/src/test/java/com/redhat/lightblue/config/MetadataConfigurationTest.java
+++ b/config/src/test/java/com/redhat/lightblue/config/MetadataConfigurationTest.java
@@ -18,22 +18,25 @@
  */
 package com.redhat.lightblue.config;
 
+import static com.redhat.lightblue.util.JsonUtils.json;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.lightblue.Response;
 import com.redhat.lightblue.metadata.EntityInfo;
 import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.Metadata;
+import com.redhat.lightblue.metadata.MetadataRoles;
 import com.redhat.lightblue.metadata.MetadataStatus;
 import com.redhat.lightblue.metadata.VersionInfo;
 import com.redhat.lightblue.metadata.parser.Extensions;
 import com.redhat.lightblue.metadata.parser.JSONMetadataParser;
-import static com.redhat.lightblue.util.JsonUtils.json;
 import com.redhat.lightblue.util.test.FileUtil;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Test the AbstractMetadataConfiguration functionality.
@@ -106,7 +109,7 @@ public class MetadataConfigurationTest {
         }
 
         @Override
-        public Map<String, List<String>> getMappedRoles() {
+        public Map<MetadataRoles, List<String>> getMappedRoles() {
             return null;
         }
 

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/AbstractMetadata.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/AbstractMetadata.java
@@ -18,7 +18,11 @@
  */
 package com.redhat.lightblue.metadata;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -27,7 +31,7 @@ import java.util.*;
 public abstract class AbstractMetadata implements Metadata {
     public static final String SEMVER_REGEX = "^\\d+\\.\\d+\\.\\d+(-.*)?$";
 
-    protected Map<String, List<String>> roleMap;
+    protected Map<MetadataRoles, List<String>> roleMap;
 
     /**
      * Checks that the given version exists, raises an error if it does not.
@@ -117,11 +121,11 @@ public abstract class AbstractMetadata implements Metadata {
     }
 
     @Override
-    public Map<String, List<String>> getMappedRoles() {
+    public Map<MetadataRoles, List<String>> getMappedRoles() {
         return roleMap;
     }
 
-    public void setRoleMap(Map<String, List<String>> roleMap) {
+    public void setRoleMap(Map<MetadataRoles, List<String>> roleMap) {
         this.roleMap = roleMap;
     }
 }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/Metadata.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/Metadata.java
@@ -18,11 +18,11 @@
  */
 package com.redhat.lightblue.metadata;
 
-import com.redhat.lightblue.Response;
-
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+
+import com.redhat.lightblue.Response;
 
 /**
  * Metadata manager interface
@@ -95,9 +95,9 @@ public interface Metadata extends Serializable {
      * Sets the status of a particular version of an entity
      */
     void setMetadataStatus(String entityName,
-                           String version,
-                           MetadataStatus newStatus,
-                           String comment);
+            String version,
+            MetadataStatus newStatus,
+            String comment);
 
     /**
      * Remove all entity records only if all versions of the entity are disabled
@@ -108,6 +108,6 @@ public interface Metadata extends Serializable {
      * Return the Map of all Roles configured for authorization. The roles names
      * are defined in com.redhat.lightblue.metadata.MetadataRoles enum
      */
-    Map<String, List<String>> getMappedRoles();
+    Map<MetadataRoles, List<String>> getMappedRoles();
 
 }

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/TestAbstractMetadataTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/TestAbstractMetadataTest.java
@@ -18,13 +18,14 @@
  */
 package com.redhat.lightblue.metadata;
 
-import com.redhat.lightblue.Response;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.Map;
+import com.redhat.lightblue.Response;
 
 /**
  * Named a bit strangely in case we exclude tests that begin with "Abstract",
@@ -107,7 +108,7 @@ public class TestAbstractMetadataTest {
             }
 
             @Override
-            public Map<String, List<String>> getMappedRoles() {
+            public Map<MetadataRoles, List<String>> getMappedRoles() {
                 return null;
             }
         };
@@ -118,12 +119,12 @@ public class TestAbstractMetadataTest {
     public void checkVersionIsValid_Valid() {
         // test a bunch of values that should be valid
         String[] values = new String[]{
-            "1.0.0",
-            "1.1.0",
-            "100.344.88999",
-            "1.0.0-alpha",
-            "1.0.3-SNAPSHOT",
-            "1.0.4-100"
+                "1.0.0",
+                "1.1.0",
+                "100.344.88999",
+                "1.0.0-alpha",
+                "1.0.3-SNAPSHOT",
+                "1.0.4-100"
         };
         for (String value : values) {
             Assert.assertNotNull(value, metadata.checkVersionIsValid(new Version(value, null, null)));
@@ -134,15 +135,15 @@ public class TestAbstractMetadataTest {
     public void checkVersionIsValid_Invalid() {
         // test a bunch of values that should be invalid
         String[] values = new String[]{
-            "1.0.0x",
-            "100.344.88.999",
-            "1.0.0.alpha",
-            "1.0.3.SNAPSHOT",
-            "1.0-4-100",
-            "bob",
-            " 1.0.0",
-            "100",
-            "1.0"
+                "1.0.0x",
+                "100.344.88.999",
+                "1.0.0.alpha",
+                "1.0.3.SNAPSHOT",
+                "1.0-4-100",
+                "bob",
+                " 1.0.0",
+                "100",
+                "1.0"
         };
         for (String value : values) {
             try {

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/test/DatabaseMetadata.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/test/DatabaseMetadata.java
@@ -18,11 +18,16 @@
  */
 package com.redhat.lightblue.metadata.test;
 
-import com.redhat.lightblue.Response;
-import com.redhat.lightblue.metadata.*;
-
 import java.util.List;
 import java.util.Map;
+
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.metadata.EntityInfo;
+import com.redhat.lightblue.metadata.EntityMetadata;
+import com.redhat.lightblue.metadata.Metadata;
+import com.redhat.lightblue.metadata.MetadataRoles;
+import com.redhat.lightblue.metadata.MetadataStatus;
+import com.redhat.lightblue.metadata.VersionInfo;
 
 /**
  *
@@ -92,7 +97,7 @@ public class DatabaseMetadata implements Metadata {
     }
 
     @Override
-    public Map<String, List<String>> getMappedRoles() {
+    public Map<MetadataRoles, List<String>> getMappedRoles() {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }


### PR DESCRIPTION
Just use MetadataRoles in the Hash, no need to use the String values.