### PR TITLE
Entity metadata validation only checks top level fields. When this is fi...

### DIFF
--- a/metadata/src/main/java/com/redhat/lightblue/metadata/EntityMetadata.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/EntityMetadata.java
@@ -47,9 +47,6 @@ public class EntityMetadata implements Serializable {
     public EntityMetadata(EntityInfo info, EntitySchema schema) {
         this.info = info;
         this.schema = schema;
-
-        // validate EntityMetadata (right now just enum constraint validation)
-        validate();
     }
 
     public EntityInfo getEntityInfo() {
@@ -198,18 +195,18 @@ public class EntityMetadata implements Serializable {
      */
     public void validate() {
         // Check enum in schema against entity info
-        Iterator<Field> fields = getEntitySchema().getFields().getFields();
-
-        while (fields.hasNext()) {
-            // for each field verify enum constraints
-            Field field = fields.next();
-
-            for (FieldConstraint fc : field.getConstraints()) {
-                if (fc instanceof EnumConstraint) {
-                    // check that this field's enum name is valid
-                    String enumName = ((EnumConstraint) fc).getName();
-                    if (getEntityInfo().getEnums().getEnum(enumName) == null) {
-                        throw Error.get(MetadataConstants.ERR_INVALID_ENUM, enumName);
+        FieldCursor cursor=getEntitySchema().getFieldCursor();
+        while(cursor.next()) {
+            FieldTreeNode node=cursor.getCurrentNode();
+            if(node instanceof Field) {
+                Field field=(Field)node;
+                for (FieldConstraint fc : field.getConstraints()) {
+                    if (fc instanceof EnumConstraint) {
+                        // check that this field's enum name is valid
+                        String enumName = ((EnumConstraint) fc).getName();
+                        if (getEntityInfo().getEnums().getEnum(enumName) == null) {
+                            throw Error.get(MetadataConstants.ERR_INVALID_ENUM, enumName);
+                        }
                     }
                 }
             }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/MetadataConstants.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/MetadataConstants.java
@@ -41,7 +41,7 @@ public final class MetadataConstants {
     public static final String ERR_ILL_FORMED_METADATA = "metadata:IllFormedMetadata";
     public static final String ERR_INVALID_BACKEND = "metadata:InvalidBackend";
     public static final String ERR_INVALID_INDEX = "metadata:InvalidIndex";
-    public static final String ERR_INVALID_ENUM = "metadata:InvalidEmum";
+    public static final String ERR_INVALID_ENUM = "metadata:InvalidEnum";
     public static final String ERR_INVALID_HOOK = "metadata:InvalidHook";
     public static final String ERR_UNKNOWN_BACKEND = "metadata:UnknownBackend";
     public static final String ERR_INVALID_CONSTRAINT = "metadata:InvalidConstraint";

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/MetadataValidationTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/MetadataValidationTest.java
@@ -1,0 +1,126 @@
+/*
+ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.metadata;
+
+import java.util.Set;
+import java.util.HashSet;
+import java.util.ArrayList;
+
+import com.redhat.lightblue.metadata.types.*;
+import com.redhat.lightblue.metadata.constraints.*;
+
+import com.redhat.lightblue.util.Error;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetadataValidationTest {
+
+    @Test
+    public void valid() throws Exception {
+        EntityMetadata e = new EntityMetadata("testEntity");
+        e.setVersion(new Version("1.0.0", null, "some text blah blah"));
+        e.setStatus(MetadataStatus.ACTIVE);
+        e.getFields().put(new SimpleField("field1", StringType.TYPE));
+        ObjectField o = new ObjectField("field2");
+        o.getFields().put(new SimpleField("x", IntegerType.TYPE));
+        e.getFields().put(o);
+        com.redhat.lightblue.metadata.Enum enumdef=new  com.redhat.lightblue.metadata.Enum("en");
+        Set<String> envalues=new HashSet<>();
+        envalues.add("value");
+        enumdef.setValues(envalues);
+        e.getEntityInfo().getEnums().addEnum(enumdef);
+
+        SimpleField s=new SimpleField("z",StringType.TYPE);
+        ArrayList<FieldConstraint> enumsc=new ArrayList<>();
+        EnumConstraint enumc=new EnumConstraint();
+        enumc.setName("en");
+        enumsc.add(enumc);
+        s.setConstraints(enumsc);
+        e.getFields().put(s);
+
+        s=new SimpleField("x",StringType.TYPE);
+        enumsc=new ArrayList<>();
+        enumc=new EnumConstraint();
+        enumc.setName("en");
+        enumsc.add(enumc);
+        s.setConstraints(enumsc);
+        o.getFields().put(s);
+        
+        e.validate();
+    }
+
+    // Check if a first-level field enum constraint is validated
+    @Test
+    public void invalid1() throws Exception {
+        EntityMetadata e = new EntityMetadata("testEntity");
+        e.setVersion(new Version("1.0.0", null, "some text blah blah"));
+        e.setStatus(MetadataStatus.ACTIVE);
+        e.getFields().put(new SimpleField("field1", StringType.TYPE));
+        ObjectField o = new ObjectField("field2");
+        o.getFields().put(new SimpleField("x", IntegerType.TYPE));
+        e.getFields().put(o);
+        com.redhat.lightblue.metadata.Enum enumdef=new  com.redhat.lightblue.metadata.Enum("blah");
+        Set<String> envalues=new HashSet<>();
+        envalues.add("value");
+        enumdef.setValues(envalues);
+        e.getEntityInfo().getEnums().addEnum(enumdef);
+
+        SimpleField s=new SimpleField("z",StringType.TYPE);
+        ArrayList<FieldConstraint> enumsc=new ArrayList<>();
+        EnumConstraint enumc=new EnumConstraint();
+        enumc.setName("en");
+        enumsc.add(enumc);
+        s.setConstraints(enumsc);
+        e.getFields().put(s);
+        try {
+            e.validate();
+            Assert.fail();
+        } catch (Error ex) {}
+    }
+
+    // Check if a second-level field enum constraint is validated
+    @Test
+    public void invalid2() throws Exception {
+        EntityMetadata e = new EntityMetadata("testEntity");
+        e.setVersion(new Version("1.0.0", null, "some text blah blah"));
+        e.setStatus(MetadataStatus.ACTIVE);
+        e.getFields().put(new SimpleField("field1", StringType.TYPE));
+        ObjectField o = new ObjectField("field2");
+        o.getFields().put(new SimpleField("x", IntegerType.TYPE));
+        e.getFields().put(o);
+        com.redhat.lightblue.metadata.Enum enumdef=new  com.redhat.lightblue.metadata.Enum("blah");
+        Set<String> envalues=new HashSet<>();
+        envalues.add("value");
+        enumdef.setValues(envalues);
+        e.getEntityInfo().getEnums().addEnum(enumdef);
+
+        SimpleField s=new SimpleField("x",StringType.TYPE);
+        ArrayList<FieldConstraint> enumsc=new ArrayList<>();
+        EnumConstraint enumc=new EnumConstraint();
+        enumc.setName("en");
+        enumsc.add(enumc);
+        s.setConstraints(enumsc);
+        o.getFields().put(s);
+        try {
+            e.validate();
+            Assert.fail();
+        } catch (Error ex) {}
+    }
+}


### PR DESCRIPTION
...xed, validation fails during CompositeMetadata construction, so removed validation during construction as well.