### PR TITLE
Removed oraclejdk7 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 jdk:
     - openjdk7
     - oraclejdk8
-    - oraclejdk7
 before_install:
     - cp ./etc/settings.xml ~/.m2/
     - cp ./etc/onFailure.sh  ~/


### PR DESCRIPTION
We only have oraclejdk8 because openjdk8 isn't available on travis.

* https://github.com/travis-ci/travis-ci/issues/1647
* http://docs.travis-ci.com/user/languages/java/#Overview