### PR TITLE
Fix java7 servo graphite setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,17 +117,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-core</artifactId>
-                <version>1.4.0-RC5</version>
+                <version>1.4.0</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-metrics-event-stream</artifactId>
-                <version>1.4.0-RC5</version>
+                <version>1.4.0</version>
             </dependency>
             <dependency>
                 <groupId>com.netflix.hystrix</groupId>
                 <artifactId>hystrix-servo-metrics-publisher</artifactId>
-                <version>1.4.0-RC5</version>
+                <version>1.4.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>

--- a/util/src/main/java/com/redhat/lightblue/util/ServoGraphiteSetup.java
+++ b/util/src/main/java/com/redhat/lightblue/util/ServoGraphiteSetup.java
@@ -18,6 +18,7 @@
  */
 package com.redhat.lightblue.util;
 
+import com.netflix.hystrix.Hystrix;
 import com.netflix.hystrix.contrib.servopublisher.HystrixServoMetricsPublisher;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.servo.publish.*;
@@ -180,6 +181,10 @@ public final class ServoGraphiteSetup {
         if (initialized) {
             return;
         }
+
+        // Fix Java 7 problem that initialized Hystrix/Servo before the it has been even called
+        Hystrix.reset();
+        HystrixPlugins.reset();
 
         // register hystrix servo metrics publisher, required for collecting hystrix metrics
         HystrixPlugins.getInstance().registerMetricsPublisher(HystrixServoMetricsPublisher.getInstance());


### PR DESCRIPTION
This issue was found in the build of https://github.com/lightblue-platform/lightblue-rest/pull/99 only on openJDK7 ( https://travis-ci.org/lightblue-platform/lightblue-rest/jobs/52183820 ) . The issue was the following:

java.lang.ExceptionInInitializerError
 at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
 at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
 at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
 at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
 at org.jboss.weld.introspector.jlr.WeldConstructorImpl.newInstance(WeldConstructorImpl.java:206)
 at org.jboss.weld.injection.ConstructorInjectionPoint.newInstance(ConstructorInjectionPoint.java:117)
 at org.jboss.weld.bean.ManagedBean.createInstance(ManagedBean.java:340)
 at org.jboss.weld.bean.ManagedBean$ManagedBeanInjectionTarget.produce(ManagedBean.java:204)
 at org.jboss.weld.bean.ManagedBean.create(ManagedBean.java:296)
 at org.jboss.weld.context.unbound.DependentContextImpl.get(DependentContextImpl.java:68)
 at org.jboss.weld.manager.BeanManagerImpl.getReference(BeanManagerImpl.java:626)
 at org.jboss.weld.manager.BeanManagerImpl.getReference(BeanManagerImpl.java:692)
 at org.jboss.weld.injection.FieldInjectionPoint.inject(FieldInjectionPoint.java:136)
 at org.jboss.weld.util.Beans.injectBoundFields(Beans.java:796)
 at org.jboss.weld.util.Beans.injectFieldsAndInitializers(Beans.java:805)
 at org.jboss.weld.manager.SimpleInjectionTarget$1.proceed(SimpleInjectionTarget.java:106)
 at org.jboss.weld.injection.InjectionContextImpl.run(InjectionContextImpl.java:48)
 at org.jboss.weld.manager.SimpleInjectionTarget.inject(SimpleInjectionTarget.java:102)
 at org.jboss.arquillian.testenricher.cdi.CDIInjectionEnricher.injectNonContextualInstance(CDIInjectionEnricher.java:145)
...
 at org.jboss.arquillian.junit.Arquillian.run(Arquillian.java:166)
 at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:236)
...
 at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:74)
Caused by: java.lang.IllegalStateException: Another strategy was already registered.
 at com.netflix.hystrix.strategy.HystrixPlugins.registerMetricsPublisher(HystrixPlugins.java:168)
 at com.redhat.lightblue.util.ServoGraphiteSetup.doInitialize(ServoGraphiteSetup.java:185)
 at com.redhat.lightblue.util.ServoGraphiteSetup.initialize(ServoGraphiteSetup.java:74)
 at com.redhat.lightblue.rest.metadata.MetadataResource.<clinit>(MetadataResource.java:31)