### PR TITLE
Moved hystrix/servo/statsd/graphite config from util to new module: hystrix

### DIFF
--- a/hystrix/pom.xml
+++ b/hystrix/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    Copyright 2013 Red Hat, Inc. and/or its affiliates.
+
+    This file is part of lightblue.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses />.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.redhat.lightblue</groupId>
+        <artifactId>lightblue-core-pom</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+    <groupId>com.redhat.lightblue</groupId>
+    <artifactId>lightblue-core-hystrix</artifactId>
+    <packaging>jar</packaging>
+    <version>1.3.0-SNAPSHOT</version>
+    <name>lightblue-core: ${project.groupId}|${project.artifactId}</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-servo-metrics-publisher</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.servo</groupId>
+            <artifactId>servo-graphite</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.timgroup</groupId>
+            <artifactId>java-statsd-client</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/hystrix/src/main/java/com/redhat/lightblue/hystrix/ServoGraphiteSetup.java
+++ b/hystrix/src/main/java/com/redhat/lightblue/hystrix/ServoGraphiteSetup.java
@@ -16,14 +16,14 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.redhat.lightblue.util;
+package com.redhat.lightblue.hystrix;
 
 import com.netflix.hystrix.Hystrix;
 import com.netflix.hystrix.contrib.servopublisher.HystrixServoMetricsPublisher;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.servo.publish.*;
 import com.netflix.servo.publish.graphite.GraphiteMetricObserver;
-import com.redhat.lightblue.util.statsd.StatsdMetricObserver;
+import com.redhat.lightblue.hystrix.statsd.StatsdMetricObserver;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;

--- a/hystrix/src/main/java/com/redhat/lightblue/hystrix/statsd/StatsdMetricObserver.java
+++ b/hystrix/src/main/java/com/redhat/lightblue/hystrix/statsd/StatsdMetricObserver.java
@@ -16,7 +16,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.redhat.lightblue.util.statsd;
+package com.redhat.lightblue.hystrix.statsd;
 
 import java.util.List;
 

--- a/hystrix/src/test/java/com/redhat/lightblue/hystrix/ServoGraphiteSetupTest.java
+++ b/hystrix/src/test/java/com/redhat/lightblue/hystrix/ServoGraphiteSetupTest.java
@@ -16,11 +16,11 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.redhat.lightblue.util;
+package com.redhat.lightblue.hystrix;
 
 import com.netflix.servo.publish.MetricObserver;
 import com.netflix.servo.publish.graphite.GraphiteMetricObserver;
-import com.redhat.lightblue.util.statsd.StatsdMetricObserver;
+import com.redhat.lightblue.hystrix.statsd.StatsdMetricObserver;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;

--- a/pom.xml
+++ b/pom.xml
@@ -151,14 +151,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.netflix.servo</groupId>
-            <artifactId>servo-graphite</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.netflix.hystrix</groupId>
-            <artifactId>hystrix-servo-metrics-publisher</artifactId>
-        </dependency>
     </dependencies>
     <modules>
         <module>core-api</module>
@@ -168,6 +160,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
         <module>util</module>
         <module>config</module>
         <module>test</module>
+        <module>hystrix</module>
     </modules>
     <properties>
         <sonar.exclusions>**/*Test.java,**/*Exception.java</sonar.exclusions>


### PR DESCRIPTION
The idea here is to reuse this new module in other places without pulling along other dependencies.  Specifically, the lightblue-client for https://github.com/lightblue-platform/lightblue-client/issues/57 will be adding use of hystrix commands and needs this functionality.  I don't want to recreate it.  Another option if this is not desired is to split this out into a new repo so it's completely separate from lightblue-core.

Subsequent PR for lightblue-rest will be put in to use this new dependency.