### PR TITLE
provide a mechanism for tests to provide their own custom json for light.blue-crud.json and lightblue-metadata.json

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
@@ -97,7 +97,9 @@ public abstract class AbstractCRUDTestController {
     public AbstractCRUDTestController(boolean loadStatically) throws Exception {
         if (!loadStatically || lightblueFactory == null) {
             lightblueFactory = new LightblueFactory(
-                    new DataSourcesConfiguration(getDatasourcesJson()));
+                    new DataSourcesConfiguration(getDatasourcesJson()),
+                    getLightblueCrudJson(),
+                    getLightblueMetadataJson());
 
             JsonTranslator tx = lightblueFactory.getJsonTranslator();
 
@@ -106,6 +108,26 @@ public abstract class AbstractCRUDTestController {
                 metadata.createNewMetadata(tx.parse(EntityMetadata.class, metadataJson));
             }
         }
+    }
+
+    /**
+     * Creates and returns an instance of {@link JsonNode} that represents the
+     * relevant lightblue-crud.json. If not set by a subclass, then the default settings will be used.
+     * @return the {@link JsonNode} to use when configuring the lightblue crud controllers, or <code>null</code> to use
+     * the default {@link LightblueFactory} setting.
+     */
+    protected JsonNode getLightblueCrudJson() throws Exception {
+        return null;
+    }
+
+    /**
+     * Creates and returns an instance of {@link JsonNode} that represents the
+     * relevant lightblue-metadata.json. If not set by a subclass, then the default settings will be used.
+     * @return the {@link JsonNode} to use when configuring the lightblue metadata, or <code>null</code> to use
+     * the default {@link LightblueFactory} setting.
+     */
+    protected JsonNode getLightblueMetadataJson() throws Exception {
+        return null;
     }
 
     /**


### PR DESCRIPTION
Dependency of https://github.com/lightblue-platform/lightblue-migrator/issues/142

This change allows implementations of AbstractCRUDTestController to provide a JsonNode as an alternate to lightblue-metadata.json and lightblue-crud.json.