### PR TITLE
Fixes lightblue-platform/lightblue-audit-hook#38 : Hook problem - audit currently records all fields during an update, not just the modified fields

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/crud/DocCtx.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/DocCtx.java
@@ -49,6 +49,7 @@ public class DocCtx extends JsonDoc {
     private final List<Error> errors = new ArrayList<>();
     private JsonDoc outputDoc = this;
     private JsonDoc originalDoc = null;
+    private JsonDoc originalOutputDoc = null;
     private CRUDOperation CRUDOperationPerformed;
     private final Map<String, Object> propertyMap = new HashMap<>();
 
@@ -112,7 +113,7 @@ public class DocCtx extends JsonDoc {
         originalDoc = copy();
     }
 
-    /*
+    /**
      * This method is to be called before starting making
      * modifications on the document, so that a copy of the original
      * can be saved. It'll create a copy of the current status of the
@@ -121,6 +122,9 @@ public class DocCtx extends JsonDoc {
     public void startModifications() {
         if (originalDoc == null || originalDoc == this) {
             copyOriginalFromThis();
+        }
+        if (originalOutputDoc == null || originalOutputDoc == outputDoc) {
+            copyOriginalOutputFromOutput();
         }
     }
 
@@ -170,4 +174,28 @@ public class DocCtx extends JsonDoc {
     public void setProperty(String name, Object value) {
         propertyMap.put(name, value);
     }
+
+    /**
+     * Returns the copy of the output document before any modifications (such as projections)
+     */
+    public JsonDoc getOriginalOutputDocument() {
+        return originalOutputDoc;
+    }
+
+    /**
+     * Sets the originalOutputDoc to a copy of outputDoc
+     */
+    public void copyOriginalOutputFromOutput() {
+        if(outputDoc != null) {
+            originalOutputDoc = outputDoc.copy();
+        }
+    }
+
+    /**
+     * Sets the copy of the output document before any modifications
+     */
+    public void setOriginalOutputDocument(JsonDoc doc) {
+        originalOutputDoc = doc;
+    }
+
 }

--- a/crud/src/main/java/com/redhat/lightblue/crud/DocCtx.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/DocCtx.java
@@ -33,7 +33,7 @@ import com.redhat.lightblue.DataError;
  * This class represents a document and its related copies, errors, and the
  * operation performed on the document
  *
- * DocCtx provides three views of a document:
+ * DocCtx provides four views of a document:
  * <ul>
  * <li>DocCtx instance: This is the document on which we operate.</li>
  * <li>originalDoc: This is the copy of the document before any modifications
@@ -42,14 +42,16 @@ import com.redhat.lightblue.DataError;
  * returned. Initially it points to DocCtx instance, and must be explicitly set
  * to point to something else if projections are applied, or null if document
  * will not appear in the output.</li>
+ * <li>updatedDoc: This is the copy of the unprojected updated document .
+ * This has to be explicitly set (expected on the update & save operations). </li>
  * </ul>
  */
 public class DocCtx extends JsonDoc {
 
     private final List<Error> errors = new ArrayList<>();
-    private JsonDoc outputDoc = this;
     private JsonDoc originalDoc = null;
-    private JsonDoc originalOutputDoc = null;
+    private JsonDoc outputDoc = this;
+    private JsonDoc updatedDoc = null;
     private CRUDOperation CRUDOperationPerformed;
     private final Map<String, Object> propertyMap = new HashMap<>();
 
@@ -86,14 +88,14 @@ public class DocCtx extends JsonDoc {
     }
 
     /**
-     * The output document
+     * Returns the projected output document
      */
     public JsonDoc getOutputDocument() {
         return outputDoc;
     }
 
     /**
-     * The output document
+     * Set the projected output document
      */
     public void setOutputDocument(JsonDoc doc) {
         this.outputDoc = doc;
@@ -107,7 +109,7 @@ public class DocCtx extends JsonDoc {
     }
 
     /**
-     * Sets the originalDocument to a copy of this
+     * Sets the original document to a copy of this object reference
      */
     public void copyOriginalFromThis() {
         originalDoc = copy();
@@ -117,14 +119,16 @@ public class DocCtx extends JsonDoc {
      * This method is to be called before starting making
      * modifications on the document, so that a copy of the original
      * can be saved. It'll create a copy of the current status of the
-     * document if there isn't one set already.
+     * document if there isn't one set already. If the output
+     * document has already set, it will also make a copy to the
+     * updated document field
      */
     public void startModifications() {
         if (originalDoc == null || originalDoc == this) {
             copyOriginalFromThis();
         }
-        if (originalOutputDoc == null || originalOutputDoc == outputDoc) {
-            copyOriginalOutputFromOutput();
+        if (updatedDoc == null || updatedDoc == outputDoc) {
+            copyUpdatedDocFromOutputDoc();
         }
     }
 
@@ -176,26 +180,27 @@ public class DocCtx extends JsonDoc {
     }
 
     /**
-     * Returns the copy of the output document before any modifications (such as projections)
+     * Returns the copy of the unprojected output document. To access the projected output document,
+     * see getOutputDocument() method
      */
-    public JsonDoc getOriginalOutputDocument() {
-        return originalOutputDoc;
+    public JsonDoc getUpdatedDocument() {
+        return updatedDoc;
     }
 
     /**
-     * Sets the originalOutputDoc to a copy of outputDoc
+     * Sets the unprojected output document to a copy of output document
      */
-    public void copyOriginalOutputFromOutput() {
+    public void copyUpdatedDocFromOutputDoc() {
         if(outputDoc != null) {
-            originalOutputDoc = outputDoc.copy();
+            updatedDoc = outputDoc.copy();
         }
     }
 
     /**
-     * Sets the copy of the output document before any modifications
+     * Sets a JsonDoc which must contain the unprojected updated document
      */
-    public void setOriginalOutputDocument(JsonDoc doc) {
-        originalOutputDoc = doc;
+    public void setUpdatedDocument(JsonDoc doc) {
+        updatedDoc = doc;
     }
 
 }

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -79,17 +79,18 @@ public class HookManager {
                     pre = null;
                 }
             }
-            // If original copy is the same instance as the document
-            // copy, use the same pre value as post value otherwise,
-            // copy the doc and use that as the post value
             // If we're deleting, post copy is null
             if (op == CRUDOperation.DELETE) {
                 post = null;
             } else {
-                if (doc.getOriginalDocument() == doc && pre != null) {
-                    post = pre;
+                if(doc.getOriginalOutputDocument() != null) {
+                    post = doc.getOriginalOutputDocument().copy();
                 } else {
-                    post = doc.copy();
+                    if (doc.getOriginalDocument() == doc && pre != null) {
+                        post = pre;
+                    } else {
+                        post = doc.copy();
+                    }
                 }
             }
             this.hooks = hooks;

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -83,8 +83,8 @@ public class HookManager {
             if (op == CRUDOperation.DELETE) {
                 post = null;
             } else {
-                if(doc.getOriginalOutputDocument() != null) {
-                    post = doc.getOriginalOutputDocument().copy();
+                if(doc.getUpdatedDocument() != null) {
+                    post = doc.getUpdatedDocument().copy();
                 } else {
                     if (doc.getOriginalDocument() == doc && pre != null) {
                         post = pre;

--- a/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
@@ -69,7 +69,7 @@ public class HookManagerTest extends AbstractJsonNodeTest {
             if (CRUDOperation.UPDATE.equals(op) || CRUDOperation.DELETE.equals(op)) {
                 // for update and delete setup the original document so pre isn't null in hooks
                 for (DocCtx dc : getDocuments()) {
-                    dc.copyOriginalFromThis();
+                    dc.startModifications();
                 }
             }
         }


### PR DESCRIPTION
The issue https://github.com/lightblue-platform/lightblue-audit-hook/issues/38