### PR TITLE
Don't process NullNodes in CompositeFind

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
@@ -266,6 +266,7 @@ public class CompositeFindImpl implements Finder {
                                 List<DocCtx> resultDocuments,
                                 Projection projection) {
         // Project results
+        LOGGER.debug("Projecting association result using {}",projection.toString());
         FieldAccessRoleEvaluator roleEval = new FieldAccessRoleEvaluator(root, ctx.getCallerRoles());
         Projector projector = Projector.getInstance(Projection.add(projection, 
                                                                    roleEval.getExcludedFields(FieldAccessRoleEvaluator.Operation.find)), root);

--- a/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 
 import com.redhat.lightblue.OperationStatus;
 
@@ -283,7 +284,7 @@ public class CompositeFindImpl implements Finder {
                     Path insertInto=ref.getReferenceField();
                     JsonNode insertionNode=doc.getDoc().get(insertInto);
                     LOGGER.debug("Inserting reference {} to {} with {} docs",ref,insertInto,ref.getChildren().size());
-                    if(insertionNode==null) {
+                    if(insertionNode==null || insertionNode instanceof NullNode) {
                         doc.getDoc().modify(insertInto,insertionNode=factory.getNodeFactory().arrayNode(),true);
                     }
                     for(ResultDoc child:ref.getChildren()) {


### PR DESCRIPTION
or you'll get
```
24129 [Thread-14] ERROR com.redhat.lightblue.util.Error  - com.fasterxml.jackson.databind.node.NullNode cannot be cast to com.fasterxml.jackson.databind.node.ArrayNode
java.lang.ClassCastException: com.fasterxml.jackson.databind.node.NullNode cannot be cast to com.fasterxml.jackson.databind.node.ArrayNode
        at com.redhat.lightblue.mediator.CompositeFindImpl.retrieveFragments(CompositeFindImpl.java:290)
        at com.redhat.lightblue.mediator.CompositeFindImpl.find(CompositeFindImpl.java:249)
        at com.redhat.lightblue.mediator.Mediator.find(Mediator.java:346)
        at com.redhat.lightblue.rest.crud.hystrix.FindCommand.run(FindCommand.java:77)
        at com.redhat.lightblue.rest.crud.hystrix.FindCommand.run(FindCommand.java:36)
```

when association query returns no results.

**TODO: create a unit test for this**