### PR TITLE
return ObjectNode instead of JsonNode, as that is what is actually being returned anyway

### DIFF
--- a/metadata/src/main/java/com/redhat/lightblue/metadata/parser/JSONMetadataParser.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/parser/JSONMetadataParser.java
@@ -203,7 +203,7 @@ public class JSONMetadataParser extends MetadataParser<JsonNode> {
     }
 
     @Override
-    public JsonNode newNode() {
+    public ObjectNode newNode() {
         return factory.objectNode();
     }
 


### PR DESCRIPTION
This can save casting later on.