### PR TITLE
add methods to support loading a resource from various loaders

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
@@ -37,6 +37,7 @@ import com.redhat.lightblue.config.JsonTranslator;
 import com.redhat.lightblue.config.LightblueFactory;
 import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.Metadata;
+import com.redhat.lightblue.util.test.AbstractJsonNodeTest;
 
 /**
  * <p>
@@ -218,7 +219,10 @@ public abstract class AbstractCRUDTestController {
      *            true if should look for resource in lightblue-core-test.jar
      * @return the resource as a String
      * @throws IOException
+     * @use {@link com.redhat.lightblue.util.test.AbstractJsonNodeTest#loadResource(String)}
+     * @use {@link com.redhat.lightblue.util.test.AbstractJsonNodeTest#loadResource(String, ClassLoader)}
      */
+    @Deprecated
     public static final String loadResource(String resourceName, boolean local) throws IOException {
         StringBuilder buff = new StringBuilder();
 

--- a/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
@@ -37,7 +37,6 @@ import com.redhat.lightblue.config.JsonTranslator;
 import com.redhat.lightblue.config.LightblueFactory;
 import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.Metadata;
-import com.redhat.lightblue.util.test.AbstractJsonNodeTest;
 
 /**
  * <p>
@@ -219,8 +218,7 @@ public abstract class AbstractCRUDTestController {
      *            true if should look for resource in lightblue-core-test.jar
      * @return the resource as a String
      * @throws IOException
-     * @use {@link com.redhat.lightblue.util.test.AbstractJsonNodeTest#loadResource(String)}
-     * @use {@link com.redhat.lightblue.util.test.AbstractJsonNodeTest#loadResource(String, ClassLoader)}
+     * @use {@link com.redhat.lightblue.util.test.AbstractJsonNodeTest#loadResource}
      */
     @Deprecated
     public static final String loadResource(String resourceName, boolean local) throws IOException {

--- a/util/src/main/java/com/redhat/lightblue/util/test/AbstractJsonNodeTest.java
+++ b/util/src/main/java/com/redhat/lightblue/util/test/AbstractJsonNodeTest.java
@@ -68,10 +68,28 @@ public abstract class AbstractJsonNodeTest {
      * @throws IOException
      */
     public static final String loadResource(String resourceName, ClassLoader loader) throws IOException {
+        try (InputStream is = loader.getResourceAsStream(resourceName)) {
+            return loadResource(is);
+        }
+    }
+
+    /**
+     * Loads contents of resource on classpath as String using the passed in {@link Class}.
+     * @param resourceName
+     * @param loader - {@link Class} to use.
+     * @return the resource as a String
+     * @throws IOException
+     */
+    public static final String loadResource(String resourceName, Class<?> loader) throws IOException {
+        try (InputStream is = loader.getResourceAsStream(resourceName)) {
+            return loadResource(is);
+        }
+    }
+
+    public static final String loadResource(InputStream is) throws IOException {
         StringBuilder buff = new StringBuilder();
 
-        try (InputStream is = loader.getResourceAsStream(resourceName);
-                InputStreamReader isr = new InputStreamReader(is, Charset.defaultCharset());
+        try (InputStreamReader isr = new InputStreamReader(is, Charset.defaultCharset());
                 BufferedReader reader = new BufferedReader(isr)) {
             String line;
             while ((line = reader.readLine()) != null) {

--- a/util/src/main/java/com/redhat/lightblue/util/test/AbstractJsonNodeTest.java
+++ b/util/src/main/java/com/redhat/lightblue/util/test/AbstractJsonNodeTest.java
@@ -18,17 +18,21 @@
  */
 package com.redhat.lightblue.util.test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.*;
-import com.redhat.lightblue.util.JsonDoc;
-import com.redhat.lightblue.util.JsonUtils;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Iterator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.JsonUtils;
 
 public abstract class AbstractJsonNodeTest {
     protected static final JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.withExactBigDecimals(true);
@@ -46,16 +50,27 @@ public abstract class AbstractJsonNodeTest {
     }
 
     /**
-     * Load contents of resource on classpath as String.
+     * Load contents of resource on classpath as String using the currentThreads {@link ClassLoader}.
      *
-     * @param resourceName
+     * @param resourceName - path to resource
      * @return the resource as a String
      * @throws IOException
      */
     public static final String loadResource(String resourceName) throws IOException {
+        return loadResource(resourceName, Thread.currentThread().getContextClassLoader());
+    }
+
+    /**
+     * Loads contents of resource on classpath as String using the passed in {@link ClassLoader}.
+     * @param resourceName - path to resource
+     * @param loader - {@link ClassLoader} to use
+     * @return the resource as a String
+     * @throws IOException
+     */
+    public static final String loadResource(String resourceName, ClassLoader loader) throws IOException {
         StringBuilder buff = new StringBuilder();
 
-        try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName);
+        try (InputStream is = loader.getResourceAsStream(resourceName);
                 InputStreamReader isr = new InputStreamReader(is, Charset.defaultCharset());
                 BufferedReader reader = new BufferedReader(isr)) {
             String line;


### PR DESCRIPTION
The load resource method in AbstractCRUDTestController was insufficient to cover all cases. I am adding methods to AbstractJsonNodeTest to better support this. A future release should clean up the deprecated method.