### PR TITLE
ValueGenerators parsing and json schema changes

### DIFF
--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -49,6 +49,11 @@
           <artifactId>lightblue-core-util</artifactId>
           <version>${project.version}</version>
        </dependency>
+       <dependency>
+          <groupId>com.redhat.lightblue</groupId>
+          <artifactId>lightblue-core-extensions</artifactId>
+          <version>${project.version}</version>
+       </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -29,6 +29,11 @@
     <packaging>jar</packaging>
     <name>lightblue-core: ${project.groupId}|${project.artifactId}</name>
     <dependencies>
+        <dependency>
+            <groupId>com.redhat.lightblue</groupId>
+            <artifactId>lightblue-core-metadata</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
     </build>

--- a/extensions/src/main/java/com/redhat/lightblue/extensions/sequence/Sequence.java
+++ b/extensions/src/main/java/com/redhat/lightblue/extensions/sequence/Sequence.java
@@ -1,0 +1,22 @@
+package com.redhat.lightblue.extensions.sequence;
+
+import com.redhat.lightblue.metadata.SimpleField;
+
+/**
+ * Sequence generation interface, to be implemented by the backend. Can return any value, but likely
+ * an integer is going to be used.
+ *
+ * @author mpatercz
+ *
+ */
+public interface Sequence<T> {
+
+    /**
+     * Generate next value in sequence. This should be handled automatically by the backend on insert.
+     *
+     * @param field
+     * @return
+     */
+    public T nextInSequence(SimpleField field);
+
+}

--- a/extensions/src/main/java/com/redhat/lightblue/extensions/sequence/SequenceSupport.java
+++ b/extensions/src/main/java/com/redhat/lightblue/extensions/sequence/SequenceSupport.java
@@ -1,0 +1,20 @@
+package com.redhat.lightblue.extensions.sequence;
+
+import com.redhat.lightblue.extensions.Extension;
+
+/**
+ * Sequence extension provides backend specific sequence generation capabilities.
+ *
+ * @author mpatercz
+ *
+ */
+public interface SequenceSupport<T> extends Extension {
+
+    /**
+     *
+     * @param backend e.g. mongo
+     * @return
+     */
+    Sequence<T> getSequenceInstance(String backend);
+
+}

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/EntityInfo.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/EntityInfo.java
@@ -36,6 +36,7 @@ public class EntityInfo implements Serializable {
     private final Hooks hooks = new Hooks();
     private final Indexes indexes = new Indexes();
     private final Enums enums = new Enums();
+    private final ValueGenerators valueGenerators = new ValueGenerators();
     private DataStore backend;
     private final Map<String, Object> properties = new HashMap<>();
 
@@ -92,5 +93,9 @@ public class EntityInfo implements Serializable {
 
     public Map<String, Object> getProperties() {
         return properties;
+    }
+
+    public ValueGenerators getValueGenerators() {
+        return valueGenerators;
     }
 }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/Field.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/Field.java
@@ -24,6 +24,9 @@ import com.redhat.lightblue.util.Path;
 import java.io.Serializable;
 import java.util.*;
 
+/**
+ * Represents arrays and objects.
+ */
 public abstract class Field implements FieldTreeNode, Serializable {
 
     private static final long serialVersionUID = 1l;
@@ -121,4 +124,5 @@ public abstract class Field implements FieldTreeNode, Serializable {
     }
 
     public abstract FieldTreeNode resolve(Path p, int level);
+
 }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/SimpleField.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/SimpleField.java
@@ -23,9 +23,15 @@ import com.redhat.lightblue.util.Path;
 
 import java.util.Iterator;
 
+/**
+ * Represents a simple field, e.g. string or number. Objects and arrays are not simple fields.
+ *
+ */
 public class SimpleField extends Field {
 
     private static final long serialVersionUID = 1L;
+
+    private ValueGenerator valueGenerator;
 
     public SimpleField(String name) {
         super(name);
@@ -33,6 +39,11 @@ public class SimpleField extends Field {
 
     public SimpleField(String name, Type type) {
         super(name, type);
+    }
+
+    public SimpleField(String name, Type type, ValueGenerator valueGenerator) {
+        this(name, type);
+        this.valueGenerator = valueGenerator;
     }
 
     @Override
@@ -54,6 +65,14 @@ public class SimpleField extends Field {
         } else {
             throw Error.get(MetadataConstants.ERR_INVALID_FIELD_REFERENCE);
         }
+    }
+
+    public ValueGenerator getValueGenerator() {
+        return valueGenerator;
+    }
+
+    public void setValueGenerator(ValueGenerator valueGenerator) {
+        this.valueGenerator = valueGenerator;
     }
 
 }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/ValueGenerator.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/ValueGenerator.java
@@ -1,0 +1,42 @@
+package com.redhat.lightblue.metadata;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+/**
+ * Represents value generator definition located in entityInfo.
+ *
+ * @author mpatercz
+ *
+ */
+public class ValueGenerator implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public enum ValueGeneratorType {
+        IntSequance;
+    }
+
+    private ValueGeneratorType type;
+    private String name;
+    private Properties properties = new Properties();
+
+    public ValueGenerator(ValueGeneratorType type, String name) {
+        super();
+        this.type = type;
+        this.name = name;
+    }
+
+    public ValueGeneratorType getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+}

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/ValueGenerator.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/ValueGenerator.java
@@ -14,21 +14,22 @@ public class ValueGenerator implements Serializable {
     private static final long serialVersionUID = 1L;
 
     public enum ValueGeneratorType {
-        IntSequance;
+        IntSequence;
     }
 
-    private ValueGeneratorType type;
-    private String name;
-    private Properties properties = new Properties();
+    // defines how values are generated
+    private final ValueGeneratorType valueGeneratorType;
+    private final String name;
+    private final Properties properties = new Properties();
 
-    public ValueGenerator(ValueGeneratorType type, String name) {
+    public ValueGenerator(ValueGeneratorType valueGeneratorType, String name) {
         super();
-        this.type = type;
+        this.valueGeneratorType = valueGeneratorType;
         this.name = name;
     }
 
-    public ValueGeneratorType getType() {
-        return type;
+    public ValueGeneratorType getValueGeneratorType() {
+        return valueGeneratorType;
     }
 
     public String getName() {

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/ValueGenerators.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/ValueGenerators.java
@@ -1,0 +1,42 @@
+package com.redhat.lightblue.metadata;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A map of {@link ValueGenerator}s. The name is the map's key and it has to be unique in entity's scope.
+ *
+ * @author mpatercz
+ *
+ */
+public class ValueGenerators implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String,ValueGenerator> valueGenerators = new HashMap<>();
+
+    public void addValueGenerator(ValueGenerator valueGenerator) {
+        if (valueGenerators.containsKey(valueGenerator.getName())) {
+            throw new IllegalArgumentException("Generator name has to be unique: "+valueGenerator.getName());
+        }
+
+        valueGenerators.put(valueGenerator.getName(), valueGenerator);
+    }
+
+    public void setValueGenerators(Collection<ValueGenerator> valueGenerators) {
+        if (valueGenerators == null)
+            return;
+
+        this.valueGenerators.clear();
+
+        for (ValueGenerator g: valueGenerators)
+            addValueGenerator(g);
+    }
+
+    public ValueGenerator getValueGenerator(String name) {
+        return valueGenerators.get(name);
+    }
+
+}

--- a/metadata/src/main/resources/json-schema/metadata/entityInfo.json
+++ b/metadata/src/main/resources/json-schema/metadata/entityInfo.json
@@ -147,6 +147,43 @@
                 ]
             }
         },
+        "valueGenerators": {
+            "type": "array",
+            "description": "Array of value generators.",
+            "items": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the value generator. Must be unique per entity."
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The type of the value generator."
+                    },
+                    "properties": {
+                        "type": "array",
+                        "description": "Properties for the value generator.",
+                        "items": {
+                            "configuration": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Property name"
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "description": "Property value"
+                                }
+                            },
+                            "required": ["name", "value"]
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "type"
+                ]
+            }
+        },
         "datastore": {
             "type": "object",
             "description": "Definition of the backend in which data is persisted.  Note that credentials are not stored here.  Pointers to credientials could be saved, such as env variables.  This entity is wide open on purpose to allow individual backend implementations to deal with parsing and validating this structure.",

--- a/metadata/src/main/resources/json-schema/metadata/schema.json
+++ b/metadata/src/main/resources/json-schema/metadata/schema.json
@@ -185,6 +185,9 @@
                                 },
                                 "description": {
                                     "type": "string"
+                                },
+                                "valueGenerator": {
+                                    "type": "string"
                                 }
                             },
                             "additionalProperties": false,

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/ValueGeneratorTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/ValueGeneratorTest.java
@@ -54,7 +54,7 @@ public class ValueGeneratorTest extends AbstractJsonNodeTest {
 
         ValueGenerator vg = md.getEntityInfo().getValueGenerators().getValueGenerator("testSeq");
         Assert.assertEquals("testSeq", vg.getName());
-        Assert.assertEquals(ValueGeneratorType.IntSequance, vg.getType());
+        Assert.assertEquals(ValueGeneratorType.IntSequence, vg.getValueGeneratorType());
         Assert.assertEquals(2, vg.getProperties().size());
         Assert.assertEquals("10000", vg.getProperties().get("min"));
         Assert.assertEquals("99999", vg.getProperties().get("max"));

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/ValueGeneratorTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/ValueGeneratorTest.java
@@ -1,0 +1,63 @@
+package com.redhat.lightblue.metadata;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.redhat.lightblue.metadata.ValueGenerator.ValueGeneratorType;
+import com.redhat.lightblue.metadata.parser.DataStoreParser;
+import com.redhat.lightblue.metadata.parser.Extensions;
+import com.redhat.lightblue.metadata.parser.JSONMetadataParser;
+import com.redhat.lightblue.metadata.parser.MetadataParser;
+import com.redhat.lightblue.metadata.types.DefaultTypes;
+import com.redhat.lightblue.util.test.AbstractJsonNodeTest;
+
+public class ValueGeneratorTest extends AbstractJsonNodeTest {
+
+    private static final JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(true);
+
+    public class TestDataStoreParser<T> implements DataStoreParser<T> {
+
+        @Override
+        public DataStore parse(String name, MetadataParser<T> p, T node) {
+            return new DataStore() {
+                public String getBackend() {
+                    return "mongo";
+                }
+            };
+        }
+
+        @Override
+        public void convert(MetadataParser<T> p, T emptyNode, DataStore object) {
+        }
+
+        @Override
+        public String getDefaultName() {
+            return "mongo";
+        }
+    }
+
+    private EntityMetadata getMd(String fname) throws Exception {
+        JsonNode node = loadJsonNode(fname);
+        Extensions<JsonNode> extensions = new Extensions<>();
+        extensions.addDefaultExtensions();
+        extensions.registerDataStoreParser("empty", new TestDataStoreParser<JsonNode>());
+        TypeResolver resolver = new DefaultTypes();
+        JSONMetadataParser parser = new JSONMetadataParser(extensions, resolver, factory);
+        return parser.parseEntityMetadata(node);
+    }
+
+    @Test
+    public void parseTest() throws Exception {
+        EntityMetadata md = getMd("metadata-json-schema-test-valid/schema-test-metadata-object-valueGenerator.json");
+
+        ValueGenerator vg = md.getEntityInfo().getValueGenerators().getValueGenerator("testSeq");
+        Assert.assertEquals("testSeq", vg.getName());
+        Assert.assertEquals(ValueGeneratorType.IntSequance, vg.getType());
+        Assert.assertEquals(2, vg.getProperties().size());
+        Assert.assertEquals("10000", vg.getProperties().get("min"));
+        Assert.assertEquals("99999", vg.getProperties().get("max"));
+    }
+
+}

--- a/metadata/src/test/resources/metadata-json-schema-test-valid/schema-test-metadata-object-valueGenerator.json
+++ b/metadata/src/test/resources/metadata-json-schema-test-valid/schema-test-metadata-object-valueGenerator.json
@@ -4,7 +4,7 @@
         "valueGenerators": [
             {
                 "name": "testSeq",
-                "type": "IntSequance",
+                "type": "IntSequence",
                 "configuration": [
                     {
                         "name": "min",

--- a/metadata/src/test/resources/metadata-json-schema-test-valid/schema-test-metadata-object-valueGenerator.json
+++ b/metadata/src/test/resources/metadata-json-schema-test-valid/schema-test-metadata-object-valueGenerator.json
@@ -1,0 +1,46 @@
+{
+    "entityInfo": {
+        "name": "test",
+        "valueGenerators": [
+            {
+                "name": "testSeq",
+                "type": "IntSequance",
+                "configuration": [
+                    {
+                        "name": "min",
+                        "value": "10000"
+                    },
+                    {
+                        "name": "max",
+                        "value": "99999"
+                    }
+                ]
+            }
+        ],
+        "datastore": {
+            "backend":"empty"
+        }
+    },
+    "schema": {
+        "name": "test",
+        "version": {
+            "value": "1.0",
+            "changelog": "Initial version"
+        },
+        "status": {
+            "value": "active"
+        },
+        "access": {
+            "insert": ["admin"],
+            "find": ["admin", "all"],
+            "update": ["admin"],
+            "delete": ["admin"]
+        },
+        "fields": {
+            "customerId": {
+                "type": "integer",
+                "valueGenerator": "testSeq"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Metadata changes for https://github.com/lightblue-platform/lightblue/pull/22. Without sequences implementation in lightblue-mongo, this does nothing. It should be merged together with lightblue-mongo changes.

