### PR TITLE
check for null from getMetadataJsonNodes in AbstractCRUDTestController

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
@@ -100,8 +100,12 @@ public abstract class AbstractCRUDTestController {
             JsonTranslator tx = lightblueFactory.getJsonTranslator();
 
             Metadata metadata = lightblueFactory.getMetadata();
-            for (JsonNode metadataJson : getMetadataJsonNodes()) {
-                metadata.createNewMetadata(tx.parse(EntityMetadata.class, metadataJson));
+
+            JsonNode[] metadataNodes = getMetadataJsonNodes();
+            if (metadataNodes != null) {
+                for (JsonNode metadataJson : metadataNodes) {
+                    metadata.createNewMetadata(tx.parse(EntityMetadata.class, metadataJson));
+                }
             }
         }
     }


### PR DESCRIPTION
No reason a returned null should break things.