### PR TITLE
fixes #458 - change all access levels to anyone

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
@@ -60,8 +60,6 @@ public abstract class AbstractCRUDTestController {
 
     private static LightblueFactory lightblueFactory;
 
-    private boolean grantAnyoneAccess = true;
-
     @AfterClass
     public static void cleanup() {
         lightblueFactory = null;
@@ -108,7 +106,7 @@ public abstract class AbstractCRUDTestController {
             JsonNode[] metadataNodes = getMetadataJsonNodes();
             if (metadataNodes != null) {
                 for (JsonNode metadataJson : metadataNodes) {
-                    if(IsGrandAnyoneAccess()){
+                    if (isGrantAnyoneAccess()) {
                         grantAnyoneAccess(metadataJson);
                     }
                     metadata.createNewMetadata(tx.parse(EntityMetadata.class, metadataJson));
@@ -196,20 +194,11 @@ public abstract class AbstractCRUDTestController {
     protected abstract JsonNode[] getMetadataJsonNodes() throws Exception;
 
     /**
-     * Sets if any access settings in metadata should be altered to 'anyone' for
-     * testing purposes. Defaults to <code>true</code>.
-     * @param grantAnyoneAccess
-     */
-    protected void setGrantAnyoneAccess(boolean grantAnyoneAccess) {
-        this.grantAnyoneAccess = grantAnyoneAccess;
-    }
-
-    /**
      * @return <code>true</code> if access settings on metadata should be altered to
      * 'anyone', otherwise <code>false</code>. Defaults to <code>true</code>.
      */
-    public boolean IsGrandAnyoneAccess() {
-        return grantAnyoneAccess;
+    public boolean isGrantAnyoneAccess() {
+        return true;
     }
 
     /**

--- a/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
@@ -23,10 +23,12 @@ import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
 
 import org.junit.AfterClass;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.redhat.lightblue.Request;
 import com.redhat.lightblue.config.DataSourcesConfiguration;
 import com.redhat.lightblue.config.JsonTranslator;
@@ -57,6 +59,8 @@ import com.redhat.lightblue.metadata.Metadata;
 public abstract class AbstractCRUDTestController {
 
     private static LightblueFactory lightblueFactory;
+
+    private boolean grantAnyoneAccess = true;
 
     @AfterClass
     public static void cleanup() {
@@ -104,8 +108,50 @@ public abstract class AbstractCRUDTestController {
             JsonNode[] metadataNodes = getMetadataJsonNodes();
             if (metadataNodes != null) {
                 for (JsonNode metadataJson : metadataNodes) {
+                    if(IsGrandAnyoneAccess()){
+                        grantAnyoneAccess(metadataJson);
+                    }
                     metadata.createNewMetadata(tx.parse(EntityMetadata.class, metadataJson));
                 }
+            }
+        }
+    }
+
+    /**
+     * Deep dives to set all access levels to 'anyone'.
+     * @param node - root {@link JsonNode}
+     */
+    public static void grantAnyoneAccess(JsonNode node) {
+        doGrantAnyoneAccess(node.get("schema"));
+    }
+
+    /**
+     * <p>Recursive Method!!</p>
+     * <p>Iterates over the {@link JsonNode} to determine if it, or any of it's
+     * sub-documents, has an access node. If so, all access settings will be changed to
+     * 'anyone'</p>
+     * @param node - {@link JsonNode} to set the access to anyone on.
+     */
+    private static void doGrantAnyoneAccess(JsonNode node) {
+        if (node.has("fields")) {
+            JsonNode fieldsNode = node.get("fields");
+            Iterator<JsonNode> fieldNodes = fieldsNode.iterator();
+            while (fieldNodes.hasNext()) {
+                doGrantAnyoneAccess(fieldNodes.next());
+            }
+        }
+
+        if (node.has("items")) {
+            doGrantAnyoneAccess(node.get("items"));
+        }
+
+        if (node.has("access")) {
+            JsonNode accessNode = node.get("access");
+            Iterator<JsonNode> accessNodes = accessNode.iterator();
+            while (accessNodes.hasNext()) {
+                ArrayNode child = (ArrayNode) accessNodes.next();
+                child.removeAll();
+                child.add("anyone");
             }
         }
     }
@@ -148,6 +194,23 @@ public abstract class AbstractCRUDTestController {
      * {@link LightblueFactory} with.
      */
     protected abstract JsonNode[] getMetadataJsonNodes() throws Exception;
+
+    /**
+     * Sets if any access settings in metadata should be altered to 'anyone' for
+     * testing purposes. Defaults to <code>true</code>.
+     * @param grantAnyoneAccess
+     */
+    protected void setGrantAnyoneAccess(boolean grantAnyoneAccess) {
+        this.grantAnyoneAccess = grantAnyoneAccess;
+    }
+
+    /**
+     * @return <code>true</code> if access settings on metadata should be altered to
+     * 'anyone', otherwise <code>false</code>. Defaults to <code>true</code>.
+     */
+    public boolean IsGrandAnyoneAccess() {
+        return grantAnyoneAccess;
+    }
 
     /**
      * Creates and returns a {@link Request} based on the passed in

--- a/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
+++ b/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
@@ -1,0 +1,27 @@
+package com.redhat.lightblue.test;
+
+import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class AbstractCRUDTestControllerTest {
+
+    @Test
+    public void testGrantAnyoneAccess() throws Exception {
+        JsonNode node = loadJsonNode("./metadata/access.json");
+        AbstractCRUDTestController.grantAnyoneAccess(node);
+
+        assertEquals("anyone", 
+                node.get("schema").get("access").get("insert").get(0).textValue());
+        assertEquals("anyone", 
+                node.get("schema").get("fields").get("anArray").get("access").get("insert").get(0).textValue());
+        assertEquals("anyone", 
+                node.get("schema").get("fields").get("anArray").get("items").get("fields").get("name").get("access").get("insert").get(0).textValue());
+        assertEquals("anyone", 
+                node.get("schema").get("fields").get("someField").get("access").get("insert").get(0).textValue());
+    }
+
+}

--- a/test/src/test/resources/metadata/access.json
+++ b/test/src/test/resources/metadata/access.json
@@ -1,0 +1,76 @@
+{
+  "schema": {
+    "access": {
+      "insert": [
+        "insert-perm"
+      ],
+      "update": [
+        "update-perm"
+      ],
+      "find": [
+        "find-perm"
+      ],
+      "delete": [
+        "delete-perm"
+      ]
+    },
+    "fields": {
+      "anArray": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "fields": {
+            "name": {
+              "type": "string",
+              "access": {
+                "insert": [
+                  "insert-perm"
+                ],
+                "update": [
+                  "update-perm"
+                ],
+                "find": [
+                  "find-perm"
+                ],
+                "delete": [
+                  "delete-perm"
+                ]
+              }
+            }
+          }
+        },
+        "access": {
+          "insert": [
+            "insert-perm"
+          ],
+          "update": [
+            "update-perm"
+          ],
+          "find": [
+            "find-perm"
+          ],
+          "delete": [
+            "delete-perm"
+          ]
+        }
+      },
+      "someField": {
+        "type": "string",
+        "access": {
+          "insert": [
+            "insert-perm"
+          ],
+          "update": [
+            "update-perm"
+          ],
+          "find": [
+            "find-perm"
+          ],
+          "delete": [
+            "delete-perm"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Does a deep dive of a metadata's in-memory JsonNode and grants all access to 'anyone' for testing purposes.