### PR TITLE
fixes #459 - selectively removes hooks from entityInfo

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/test/AbstractCRUDTestController.java
@@ -23,10 +23,15 @@ import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.AfterClass;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.lightblue.Request;
 import com.redhat.lightblue.config.DataSourcesConfiguration;
 import com.redhat.lightblue.config.JsonTranslator;
@@ -55,6 +60,8 @@ import com.redhat.lightblue.metadata.Metadata;
  * @author dcrissman
  */
 public abstract class AbstractCRUDTestController {
+
+    public static final String REMOVE_ALL_HOOKS = "ALL";
 
     private static LightblueFactory lightblueFactory;
 
@@ -104,6 +111,7 @@ public abstract class AbstractCRUDTestController {
             JsonNode[] metadataNodes = getMetadataJsonNodes();
             if (metadataNodes != null) {
                 for (JsonNode metadataJson : metadataNodes) {
+                    stripHooks(metadataJson, getHooksToRemove());
                     metadata.createNewMetadata(tx.parse(EntityMetadata.class, metadataJson));
                 }
             }
@@ -148,6 +156,41 @@ public abstract class AbstractCRUDTestController {
      * {@link LightblueFactory} with.
      */
     protected abstract JsonNode[] getMetadataJsonNodes() throws Exception;
+
+    /**
+     * Strips out the specified hooks. Pass in 'ALL' or {@link #REMOVE_ALL_HOOKS}
+     * to remove all the hooks on the node.
+     * @param node - root {@link JsonNode}
+     * @param hooksToRemove - {@link Set} of hook names to remove from entityInfo.
+     */
+    public static void stripHooks(JsonNode node, Set<String> hooksToRemove) {
+        ObjectNode entityInfoNode = (ObjectNode) node.get("entityInfo");
+
+        if (!entityInfoNode.has("hooks")) {
+            return;
+        }
+
+        if (hooksToRemove.contains(REMOVE_ALL_HOOKS)) {
+            entityInfoNode.remove("hooks");
+        }
+        else {
+            ArrayNode hooksNode = (ArrayNode) entityInfoNode.get("hooks");
+            for (int x = hooksNode.size(); x > 0; x--) {
+                JsonNode hookNode = hooksNode.get(x - 1);
+                if (hooksToRemove.contains(hookNode.get("name").textValue())) {
+                    hooksNode.remove(x - 1);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return {@link Set} of hook names to remove. By default returns
+     * {@link #REMOVE_ALL_HOOKS}, which will remove all hooks.
+     */
+    public Set<String> getHooksToRemove() {
+        return new HashSet<String>(Arrays.asList(REMOVE_ALL_HOOKS));
+    }
 
     /**
      * Creates and returns a {@link Request} based on the passed in

--- a/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
+++ b/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
@@ -35,6 +35,7 @@ public class AbstractCRUDTestControllerTest {
         assertEquals(2, hooksNode.size());
     }
 
+    @Test
     public void testGrantAnyoneAccess() throws Exception {
         JsonNode node = loadJsonNode("./metadata/access.json");
         AbstractCRUDTestController.grantAnyoneAccess(node);

--- a/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
+++ b/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
@@ -1,0 +1,38 @@
+package com.redhat.lightblue.test;
+
+import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class AbstractCRUDTestControllerTest {
+
+    @Test
+    public void testStripHooks_All() throws Exception {
+        JsonNode node = loadJsonNode("./metadata/hooks.json");
+        AbstractCRUDTestController.stripHooks(node,
+                new HashSet<String>(Arrays.asList(
+                        AbstractCRUDTestController.REMOVE_ALL_HOOKS)));
+
+        assertNull(node.get("entityInfo").get("hooks"));
+    }
+
+    @Test
+    public void testStripHooks_Selective() throws Exception {
+        JsonNode node = loadJsonNode("./metadata/hooks.json");
+        AbstractCRUDTestController.stripHooks(node,
+                new HashSet<String>(Arrays.asList("someHook")));
+
+        JsonNode hooksNode = node.get("entityInfo").get("hooks");
+        assertNotNull(hooksNode);
+        assertEquals(2, hooksNode.size());
+    }
+
+}

--- a/test/src/test/resources/metadata/hooks.json
+++ b/test/src/test/resources/metadata/hooks.json
@@ -1,0 +1,30 @@
+{
+    "entityInfo": {
+         "hooks": [
+            {
+                "name": "someHook",
+                "actions": [
+                    "insert",
+                    "update",
+                    "delete"
+                ]
+            },
+            {
+                "name": "someOtherHook",
+                "actions": [
+                    "insert",
+                    "update",
+                    "delete"
+                ]
+            },
+            {
+                "name": "yetAnotherHook",
+                "actions": [
+                    "insert",
+                    "update",
+                    "delete"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Optionally allows test cases to selectively or entirely remove hooks from in-memory JsonNodes.