### PR TITLE
Fix #472: when parent of a required field does not exist, and that pa…

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/crud/validator/RequiredChecker.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/validator/RequiredChecker.java
@@ -96,10 +96,12 @@ public class RequiredChecker implements FieldConstraintDocChecker {
             while (cursor.hasNext()) {
                 cursor.next();
                 JsonNode parentObject = cursor.getCurrentValue();
-                LOGGER.debug("Checking {}",cursor.getCurrentKey());
-                JsonNode fieldNode=parentObject.get(fieldName);
-                if (fieldNode == null || fieldNode instanceof NullNode) {
-                    errors.add(new Path(cursor.getCurrentKey() + "." + fieldName));
+                if(!(parentObject instanceof NullNode)) {
+                    LOGGER.debug("Checking {}",cursor.getCurrentKey());
+                    JsonNode fieldNode=parentObject.get(fieldName);
+                    if (fieldNode == null || fieldNode instanceof NullNode) {
+                        errors.add(new Path(cursor.getCurrentKey() + "." + fieldName));
+                    }
                 }
             }
         }

--- a/crud/src/test/java/com/redhat/lightblue/crud/validator/RequiredCheckerTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/crud/validator/RequiredCheckerTest.java
@@ -132,6 +132,7 @@ public class RequiredCheckerTest {
         verify(validator, times(1)).addDocError(any(Error.class));
     }
 
+
     /**
      * When all the paths exist, then no errors will be thrown.
      */
@@ -200,6 +201,34 @@ public class RequiredCheckerTest {
         assertNotNull(results.get(0));
         assertEquals(fieldName, results.get(0).tail(0));
         assertEquals(parentPath, results.get(0).tail(1));
+    }
+
+    @Test
+    public void testMissinParent_anys(){
+        String fieldName = "FAKE_FIELD_NAME";
+        String parentPath = "FAKE_PATH";
+
+        Path path = mock(Path.class);
+        when(path.nAnys()).thenReturn(1);
+        when(path.prefix(-1)).thenReturn(mock(Path.class));
+        when(path.tail(0)).thenReturn(fieldName);
+
+        Path kvPath = mock(Path.class);
+        when(kvPath.toString()).thenReturn(parentPath);
+
+        @SuppressWarnings("unchecked")
+        KeyValueCursor<Path, JsonNode> kvCursor = mock(KeyValueCursor.class);
+        when(kvCursor.hasNext()).thenReturn(true, false);
+        when(kvCursor.getCurrentValue()).thenReturn(JsonNodeFactory.instance.nullNode());
+        when(kvCursor.getCurrentKey()).thenReturn(kvPath);
+
+        JsonDoc doc = mock(JsonDoc.class);
+        when(doc.getAllNodes(any(Path.class))).thenReturn(kvCursor);
+
+        List<Path> results = RequiredChecker.getMissingFields(path, doc);
+
+        assertNotNull(results);
+        assertEquals(0, results.size());
     }
 
     /**


### PR DESCRIPTION
…rent is in array, validator requires the child field