### PR TITLE
Overhaul of query field treatment in associations: instead of keeping…

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/assoc/Conjunct.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/Conjunct.java
@@ -21,9 +21,8 @@ package com.redhat.lightblue.assoc;
 import java.io.Serializable;
 
 import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +31,7 @@ import com.redhat.lightblue.query.QueryExpression;
 import com.redhat.lightblue.query.FieldInfo;
 
 import com.redhat.lightblue.metadata.CompositeMetadata;
+import com.redhat.lightblue.metadata.ResolvedReferenceField;
 
 import com.redhat.lightblue.util.Path;
 
@@ -41,7 +41,7 @@ import com.redhat.lightblue.util.Path;
  * related to that clause, such as the referred nodes of query plan,
  * fieldinfo, etc.
  *
- * Object identify of conjuncts are preserved during query plan
+ * Object identity of conjuncts are preserved during query plan
  * processing. That is, a Conjunct object created for a particular
  * query plan is used again for other incarnation of that query plan,
  * only node associations are changed. So, it is possible to keep maps
@@ -57,75 +57,82 @@ public class Conjunct implements Serializable {
     private static final Logger LOGGER=LoggerFactory.getLogger(Conjunct.class);
     
     /**
-     * The query clause
+     * The original query clause
      */
     private final QueryExpression clause;
-    
+
     /**
      * Field info for the fields in the clause
      */
-    private final List<ResolvedFieldInfo> fieldInfo=new ArrayList<>();
+    private final ResolvedFieldInfo[] fieldInfo;
     
-    /**
-     * A mapping from absolute field names to the query plan nodes
-     * containing that field
-     */
-    private final Map<Path,QueryPlanNode> fieldNodeMap=new HashMap();
-
     /**
      * The list of distinct query plan nodes referred by the clause
      */
-    private final List<QueryPlanNode> referredNodes=new ArrayList<>();
+    private final Set<QueryPlanNode> referredNodes=new HashSet<>();
+
     
     public Conjunct(QueryExpression q,
                     CompositeMetadata compositeMetadata,
-                    QueryPlan qplan) {
+                    QueryPlan qplan,
+                    ResolvedReferenceField context) {
         this.clause=q;
         List<FieldInfo> fInfo=clause.getQueryFields();
-        LOGGER.debug("Conjunct for query {} with fields {}",q,fieldInfo);
+        LOGGER.debug("Conjunct for query {} with fields {}",q,fInfo);
+        fieldInfo=new ResolvedFieldInfo[fInfo.size()];
+        int index=0;
         for(FieldInfo fi:fInfo) {
-            ResolvedFieldInfo rfi=new ResolvedFieldInfo(fi,compositeMetadata);
-            fieldInfo.add(rfi);
-            CompositeMetadata cmd=compositeMetadata.getEntityOfPath(rfi.getAbsFieldName());
-            if(cmd==null)
-                throw new IllegalArgumentException("Cannot find field in composite metadata "+rfi.getAbsFieldName()); 
-            QueryPlanNode qnode=qplan.getNode(cmd);
-            if(qnode==null)
-                throw new IllegalArgumentException("An entity referenced in a query is not in composite metadata. Query:"+
-                                                   clause+" fieldInfo:"+rfi+" Composite metadata:"+cmd);
-            
-            boolean found=false;
-            for(QueryPlanNode n:referredNodes)
-                if(n==qnode) {
-                    found=true;
-                    break;
-                }
-            if(!found)
-                referredNodes.add(qnode);
-            fieldNodeMap.put(rfi.getAbsFieldName(),qnode);
+            ResolvedFieldInfo rfi=new ResolvedFieldInfo(fi,compositeMetadata,context,qplan);
+            fieldInfo[index++]=rfi;
+            referredNodes.add(rfi.getFieldQueryPlanNode());
         }
+        
+    }
+
+    /**
+     * Return the relative field name based on the original field name
+     */
+    public Path mapOriginalFieldName(Path originalFieldName) {
+        ResolvedFieldInfo fi=getFieldInfoByOriginalFieldName(originalFieldName);
+        if(fi==null)
+            return originalFieldName;
+        else
+            return fi.getEntityRelativeFieldName();
     }
 
     /**
      * Returns the nodes referenced by this clause
      */
-    public List<QueryPlanNode> getReferredNodes() {
+    public Set<QueryPlanNode> getReferredNodes() {
         return referredNodes;
-    }
-
-    /**
-     * Returns the query plan node referenced by the field. Null if the field is not in this conjunct
-     */
-    public QueryPlanNode getFieldNode(Path field) {
-        return fieldNodeMap.get(field);
     }
 
 
     /**
      * Returns the field information about the fields in the conjunct
      */
-    public List<ResolvedFieldInfo> getFieldInfo() {
+    public ResolvedFieldInfo[] getFieldInfo() {
         return fieldInfo;
+    }
+
+    /**
+     * Return the field info by the field name of the field as used in the unmodified query
+     */
+    public ResolvedFieldInfo getFieldInfoByOriginalFieldName(Path p) {
+        for(ResolvedFieldInfo fi:fieldInfo)
+            if(fi.getOriginalFieldName().equals(p))
+                return fi;
+        return null;
+    }
+
+    /**
+     * Returns the field info by the field name as it appears in the entity-relative query
+     */
+    public ResolvedFieldInfo getFieldInfoByRelativeFieldName(Path p) {
+        for(ResolvedFieldInfo fi:fieldInfo)
+            if(fi.getEntityRelativeFieldName().equals(p))
+                return fi;
+        return null;
     }
 
     /**

--- a/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldInfo.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldInfo.java
@@ -133,6 +133,13 @@ public class ResolvedFieldInfo extends FieldInfo {
         return new Path(fullPath.prefix(-nNonParent),path.suffix(nNonParent));
     }
 
+    /**
+     * Rewrites a field name relative to its entity.
+     *
+     * @param fullPath the fullpath of the field name
+     * @param path The field name as it appears in an expression. suffix of this should be the same as fullPath
+     * @param cmdPrefix The metadata entity path for the composite metadata containing the field
+     */
     public static Path getEntityRelativeFieldName(Path fullPath, Path path,Path cmdPrefix) {
         Path normalized=removeParents(fullPath,path);
         if(cmdPrefix.numSegments()>0)

--- a/crud/src/main/java/com/redhat/lightblue/assoc/scorers/IndexedFieldScorer.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/scorers/IndexedFieldScorer.java
@@ -184,11 +184,11 @@ public class IndexedFieldScorer implements QueryPlanScorer, Serializable {
             Set<Path> indexableFields=new HashSet<>();
             Indexes indexes=null;
             for(Conjunct cj:data.getConjuncts()) {
-                List<ResolvedFieldInfo> cjFields=cj.getFieldInfo();
+                ResolvedFieldInfo[] cjFields=cj.getFieldInfo();
                 // If conjunct has one field, index can be used to retrieve it
-                if(cjFields.size()==1) {
-                    indexableFields.add(cjFields.get(0).getEntityRelativeFieldName());
-                    indexes=cjFields.get(0).getFieldEntityMetadata().getEntityInfo().getIndexes();
+                if(cjFields.length==1) {
+                    indexableFields.add(cjFields[0].getEntityRelativeFieldName());
+                    indexes=cjFields[0].getFieldEntityMetadata().getEntityInfo().getIndexes();
                 }
             }
             data.setIndexableFields(indexableFields);

--- a/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
@@ -122,7 +122,7 @@ public class CompositeFindImpl implements Finder {
         if(query!=null) {
             List<FieldInfo> lfi=query.getQueryFields();
             for(FieldInfo fi:lfi) {
-                CompositeMetadata e=md.getEntityOfPath(fi.getAbsFieldName());
+                CompositeMetadata e=md.getEntityOfPath(fi.getFieldName());
                 if(e!=md)
                     entities.add(e);
             }

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -461,12 +461,12 @@ public class Mediator {
             List<FieldInfo> fields=query.getQueryFields();
             LOGGER.debug("Checking access for query fields {}",fields);
             for(FieldInfo field:fields) {
-                LOGGER.debug("Access checking field {}",field.getAbsFieldName());
-                if(eval.hasAccess(field.getAbsFieldName(),FieldAccessRoleEvaluator.Operation.find)) {
-                    LOGGER.debug("Field {} is readable",field.getAbsFieldName());
+                LOGGER.debug("Access checking field {}",field.getFieldName());
+                if(eval.hasAccess(field.getFieldName(),FieldAccessRoleEvaluator.Operation.find)) {
+                    LOGGER.debug("Field {} is readable",field.getFieldName());
                 } else {
-                    LOGGER.debug("Field {} is not readable",field.getAbsFieldName());
-                    ctx.addError(Error.get(CrudConstants.ERR_NO_ACCESS, field.getAbsFieldName().toString()));
+                    LOGGER.debug("Field {} is not readable",field.getFieldName());
+                    ctx.addError(Error.get(CrudConstants.ERR_NO_ACCESS, field.getFieldName().toString()));
                     ctx.setStatus(OperationStatus.ERROR);
                     ret=false;
                 }

--- a/crud/src/main/java/com/redhat/lightblue/mediator/QueryPlanNodeExecutor.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/QueryPlanNodeExecutor.java
@@ -109,22 +109,15 @@ public class QueryPlanNodeExecutor {
         QueryPlanNode[] sourceNodes=node.getSources();
         for(QueryPlanNode s:sourceNodes)
             sources.add(s.getProperty(QueryPlanNodeExecutor.class));
-        List<QueryExpression> queryClauses=new ArrayList<>();
 
-        // Rewrite node conjuncts relative to this node
+        List<QueryExpression> queryClauses=new ArrayList<>();
         List<Conjunct> clauses=node.getData().getConjuncts();
         if(clauses!=null) {
-            RelativeRewriteIterator rritr=new RelativeRewriteIterator(new Path(node.getMetadata().getEntityPath(),
-                                                                               Path.ANYPATH));
             for(Conjunct c:clauses) {
-                if(node.getMetadata().getParent()==null) {
-                    queryClauses.add(c.getClause());
-                } else {
-                    queryClauses.add(rritr.iterate(c.getClause()));
-                }
+                queryClauses.add(new ResolvedFieldBinding.RelativeRewriter(c).iterate(c.getClause()));
             }
         }
-
+      
         // Rewrite source edge conjuncts relative to this node, and keep binding information
         for(QueryPlanNode d:sourceNodes) {
             QueryPlanData edgeData=qplan.getEdgeData(node,d);

--- a/crud/src/test/java/com/redhat/lightblue/assoc/RelativePathTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/assoc/RelativePathTest.java
@@ -1,0 +1,36 @@
+/*
+ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.assoc;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+import com.redhat.lightblue.util.Path;
+
+public class RelativePathTest {
+    @Test
+    public void testRelativePaths() throws Exception {
+        Assert.assertEquals(new Path("a.b.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.c.d"),new Path("$parent.d"),Path.EMPTY));
+        Assert.assertEquals(new Path("a.b.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.c.d"),new Path("$parent.$parent.d"),Path.EMPTY));
+        Assert.assertEquals(new Path("a.b.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.c.d"),new Path("$parent.c.d"),Path.EMPTY));
+        Assert.assertEquals(new Path("a.b.1.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.*.c.d"),new Path("$parent.1.c.d"),Path.EMPTY));
+        Assert.assertEquals(new Path("a.b.*.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.*.c.d"),new Path("d"),Path.EMPTY));
+    }
+}
+

--- a/crud/src/test/java/com/redhat/lightblue/assoc/RelativePathTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/assoc/RelativePathTest.java
@@ -31,6 +31,9 @@ public class RelativePathTest {
         Assert.assertEquals(new Path("a.b.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.c.d"),new Path("$parent.c.d"),Path.EMPTY));
         Assert.assertEquals(new Path("a.b.1.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.*.c.d"),new Path("$parent.1.c.d"),Path.EMPTY));
         Assert.assertEquals(new Path("a.b.*.c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.*.c.d"),new Path("d"),Path.EMPTY));
+
+        Assert.assertEquals(new Path("c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.*.c.d"),new Path("c.d"),new Path("a.b")));
+        Assert.assertEquals(new Path("c.d"),ResolvedFieldInfo.getEntityRelativeFieldName(new Path("a.b.*.c.d"),new Path("$parent.d"),new Path("a.b")));
     }
 }
 

--- a/crud/src/test/java/com/redhat/lightblue/mediator/CompositeFinderTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/CompositeFinderTest.java
@@ -144,7 +144,7 @@ public class CompositeFinderTest extends AbstractJsonSchemaTest {
         return Sort.fromJson(JsonUtils.json(s.replaceAll("\'","\"")));
     }
 
-   @Test
+    @Test
     public void sanityCheck() throws Exception {
         FindRequest fr=new FindRequest();
         fr.setQuery(query("{'field':'_id','op':'=','rvalue':'A01'}"));
@@ -198,7 +198,7 @@ public class CompositeFinderTest extends AbstractJsonSchemaTest {
 
         fr.setQuery(query("{'field':'objectType','op':'=','rvalue':'A'}"));
         Response response2=mediator.find(fr);
-                        
+                      
         Assert.assertEquals(response2.getEntityData().size(),response.getEntityData().size());
     }
 
@@ -231,7 +231,7 @@ public class CompositeFinderTest extends AbstractJsonSchemaTest {
         // This one must have C -> A
         Assert.assertEquals(1,qplan.getSources().length);
         Assert.assertEquals("C",qplan.getSources()[0].getMetadata().getName());
-   }
+    }
 
     @Test
     public void retrieveAandBonly_2q() throws Exception {
@@ -357,7 +357,7 @@ public class CompositeFinderTest extends AbstractJsonSchemaTest {
     public void deepRoles() throws Exception {
         DefaultMetadataResolver r=new DefaultMetadataResolver(new TestMetadata());
         r.initialize("parent_w_elem_w_roles","1.0.0",query("{'field':'code1','op':'=','rvalue':'A'}"),projection("{'field':'relationships.*','recursive':1}"));
-        
+       
         System.out.println(r.getMetadataRoles());
         Assert.assertTrue(r.getMetadataRoles().contains("a"));
         Assert.assertTrue(r.getMetadataRoles().contains("b"));

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/CompositeMetadata.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/CompositeMetadata.java
@@ -223,8 +223,6 @@ public class CompositeMetadata extends EntityMetadata {
         Error.push("compositeMetadata");
         try {
             CompositeMetadata cmd = buildCompositeMetadata(root, gmd, new Path(), null, new MutablePath());
-            // Re-process all resolved references, rewrite their queries in absolute form
-            rewriteAssociationQueries(cmd);
             return cmd;
         } finally {
             LOGGER.debug("end buildCompositeMetadata");
@@ -347,26 +345,6 @@ public class CompositeMetadata extends EntityMetadata {
         }
     }
 
-    private static QueryExpression rewriteQuery(QueryExpression q, ResolvedReferenceField rr) {
-        return new AbsRewriteItr(rr.getElement()).iterate(q);
-    }
-
-    /**
-     * Recursively rewrites the association queries to replace all relative
-     * field references to absolute field references
-     */
-    private static void rewriteAssociationQueries(CompositeMetadata root) {
-        Set<Path> children = root.getChildPaths();
-        for (Path child : children) {
-            ResolvedReferenceField rr = root.getChildReference(child);
-            QueryExpression aq = rr.getReferenceField().getQuery();
-            if (aq != null) {
-                rr.setAbsQuery(rewriteQuery(aq, rr));
-                LOGGER.debug("Rewrote association query {} from root {} as {}", aq, root.getName(), rr.getAbsQuery());
-            }
-            rewriteAssociationQueries(rr.getReferencedMetadata());
-        }
-    }
 
     /**
      * Copy fields from source to dest.

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/Fields.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/Fields.java
@@ -115,12 +115,15 @@ public class Fields implements Serializable {
         try {
             if (p.isIndex(level)) {
                 throw Error.get(MetadataConstants.ERR_INVALID_ARRAY_REFERENCE,name+" in "+p.toString());
-            }
-            if (name.equals(Path.ANY)) {
+            } else if (name.equals(Path.ANY)) {
                 throw Error.get(MetadataConstants.ERR_INVALID_ARRAY_REFERENCE,name+" in "+p.toString());
-            }
-            if (name.equals(Path.THIS)) {
+            } else if (name.equals(Path.THIS)) {
                 return this.resolve(p, level + 1);
+            } else if(name.equals(Path.PARENT)) {
+                if(parent!=null&&!(parent instanceof EntitySchema.RootNode))
+                    return parent.resolve(p,level); // Delegate full resolution to the parent.
+                else
+                    throw Error.get(MetadataConstants.ERR_INVALID_FIELD_REFERENCE,name+" in "+p.toString());
             }
 
             Field field = getField(name);

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/ResolvedReferenceField.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/ResolvedReferenceField.java
@@ -30,7 +30,6 @@ public class ResolvedReferenceField extends ArrayField {
     private final ReferenceField reference;
     private final CompositeMetadata metadata;
     private final EntityMetadata originalMetadata;
-    private QueryExpression absQuery;
 
     public ResolvedReferenceField(ReferenceField reference,
                                   EntityMetadata originalMetadata,
@@ -57,23 +56,5 @@ public class ResolvedReferenceField extends ArrayField {
      */
     public EntityMetadata getOriginalMetadata() {
         return originalMetadata;
-    }
-
-    /**
-     * Returns the query of the reference, reinterpreted based on the resolved
-     * reference. All relative references in the original query are replaced by
-     * absolute field references.
-     */
-    public QueryExpression getAbsQuery() {
-        return absQuery;
-    }
-
-    /**
-     * Sets the query of the reference, reinterpreted based on the resolved
-     * reference. All relative references in the original query are replaced by
-     * absolute field references.
-     */
-    public void setAbsQuery(QueryExpression q) {
-        absQuery = q;
     }
 }

--- a/query-api/src/main/java/com/redhat/lightblue/query/FieldInfo.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/FieldInfo.java
@@ -29,21 +29,21 @@ import java.io.Serializable;
 public class FieldInfo implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private final Path absFieldName;
+    private final Path fieldName;
     private final Path context;
     private final QueryExpression clause;
 
     /**
      * Constructs the field info with the given information
      *
-     * @param absFieldName Absolute field name
+     * @param absFieldName Field name
      * @param context The context path under which the field is interpreted
      * @param clause The query clause containing the field
      */
-    public FieldInfo(Path absFieldName,
+    public FieldInfo(Path fieldName,
                      Path context,
                      QueryExpression clause) {
-        this.absFieldName = absFieldName;
+        this.fieldName = fieldName;
         this.context = context;
         this.clause = clause;
     }
@@ -52,14 +52,14 @@ public class FieldInfo implements Serializable {
      * Copy ctor, shallow copy
      */
     public FieldInfo(FieldInfo f) {
-        this(f.absFieldName, f.context, f.clause);
+        this(f.fieldName, f.context, f.clause);
     }
 
     /**
-     * Returns the absolute field name
+     * Returns the field name
      */
-    public Path getAbsFieldName() {
-        return absFieldName;
+    public Path getFieldName() {
+        return fieldName;
     }
 
     /**
@@ -77,6 +77,6 @@ public class FieldInfo implements Serializable {
     }
 
     public String toString() {
-        return absFieldName + "@(" + clause + ")";
+        return fieldName + "@(" + clause + ")";
     }
 }

--- a/query-api/src/main/java/com/redhat/lightblue/query/MapQueryFieldsIterator.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/MapQueryFieldsIterator.java
@@ -27,6 +27,10 @@ public class MapQueryFieldsIterator extends QueryIterator {
 
     /**
      * Override this method to map fields.
+     *
+     * The method should return a non-null path if p is to be
+     * modified. It is returns null, the original p in the expression
+     * is used.
      */
     protected Path map(Path p) {
         return p;

--- a/query-api/src/main/java/com/redhat/lightblue/query/MapQueryFieldsIterator.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/MapQueryFieldsIterator.java
@@ -1,0 +1,121 @@
+/*
+ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.query;
+
+import com.redhat.lightblue.util.Path;
+
+/**
+ * Maps query fields
+ */
+public class MapQueryFieldsIterator extends QueryIterator {
+
+    /**
+     * Override this method to map fields.
+     */
+    protected Path map(Path p) {
+        return p;
+    }
+    
+    @Override
+    protected QueryExpression itrValueComparisonExpression(ValueComparisonExpression q, Path context) {
+        Path p=map(applyContext(context,q.getField()));
+        if(p!=null)
+            return new ValueComparisonExpression(removeContext(context,p,q.getField()),q.getOp(),q.getRvalue());
+        else
+            return q;
+    }
+
+    @Override
+    protected QueryExpression itrFieldComparisonExpression(FieldComparisonExpression q, Path context) {
+    	Path r=map(applyContext(context,q.getRfield()));
+        Path l=map(applyContext(context,q.getField()));
+        if(r!=null||l!=null)
+            return new FieldComparisonExpression(l==null?q.getField():removeContext(context,l,q.getField()),
+                                                 q.getOp(),
+                                                 r==null?q.getRfield():removeContext(context,r,q.getRfield()));
+        else
+            return q;
+    }
+
+    @Override
+    protected QueryExpression itrRegexMatchExpression(RegexMatchExpression q, Path context) {
+        Path p=map(applyContext(context,q.getField()));
+        if(p!=null)
+            return new RegexMatchExpression(removeContext(context,p,q.getField()),
+                                            q.getRegex(),q.isCaseInsensitive(),q.isMultiline(),q.isExtended(),q.isDotAll());
+        else
+            return q;
+    }
+
+    @Override
+    protected QueryExpression itrNaryValueRelationalExpression(NaryValueRelationalExpression q, Path context) {
+        Path p=map(applyContext(context,q.getField()));
+        if(p!=null)
+            return new NaryValueRelationalExpression(removeContext(context,p,q.getField()),q.getOp(),q.getValues());
+        else
+            return q;
+    }
+
+    @Override
+    protected QueryExpression itrNaryFieldRelationalExpression(NaryFieldRelationalExpression q, Path context) {
+        Path r=map(applyContext(context,q.getRfield()));
+        Path l=map(applyContext(context,q.getField()));
+        if(r!=null||l!=null)
+            return new NaryFieldRelationalExpression(l==null?q.getField():removeContext(context,l,q.getField()),
+                                                     q.getOp(),
+                                                     r==null?q.getRfield():removeContext(context,r,q.getRfield()));
+        else
+            return q;
+    }
+
+    @Override
+    protected QueryExpression itrArrayContainsExpression(ArrayContainsExpression q, Path context) {
+        Path p=applyContext(context,q.getArray());
+        if(p!=null)
+            return new ArrayContainsExpression(removeContext(context,p,q.getArray()),q.getOp(),q.getValues());
+        else
+            return q;
+    }
+
+    @Override
+    protected QueryExpression itrArrayMatchExpression(ArrayMatchExpression q, Path context) {
+        ArrayMatchExpression x=(ArrayMatchExpression)super.itrArrayMatchExpression(q,context);
+        Path p=map(applyContext(context,x.getArray()));
+        if(p!=null)
+            return new ArrayMatchExpression(removeContext(context,p,x.getArray()),x.getElemMatch());
+        else
+            return x;
+    }
+    
+    private Path applyContext(Path context,Path p) {
+    	if(context.isEmpty())
+            return p;
+    	else
+            return new Path(context,p);
+    }
+
+    private Path removeContext(Path context,Path p,Path original) {
+        if(context.isEmpty())
+            return p;
+        else if(context.matchingPrefix(p))
+            return p.suffix(-context.numSegments());
+        else
+        	return original;
+    }
+}

--- a/query-api/src/test/java/com/redhat/lightblue/query/FieldInfoTest.java
+++ b/query-api/src/test/java/com/redhat/lightblue/query/FieldInfoTest.java
@@ -128,7 +128,7 @@ public class FieldInfoTest {
             Path ctx = new Path(paths[i + 1]);
             boolean found = false;
             for (FieldInfo fi : fields) {
-                if (fi.getAbsFieldName().equals(field) && fi.getContext().equals(ctx)) {
+                if (fi.getFieldName().equals(field) && fi.getContext().equals(ctx)) {
                     found = true;
                     break;
                 }

--- a/util/src/main/java/com/redhat/lightblue/util/Path.java
+++ b/util/src/main/java/com/redhat/lightblue/util/Path.java
@@ -344,8 +344,8 @@ public class Path implements Comparable<Path>, Serializable {
     }
 
     /**
-     * Returns a path with all $parent and $this references removed. This must
-     * be called on absolute paths
+     * Returns a path with all possible $parent and $this references removed. 
+     * If there are prefixing $parents, they will remain.
      */
     public Path normalize() {
         boolean parentThisPresent = false;
@@ -362,7 +362,7 @@ public class Path implements Comparable<Path>, Serializable {
             dataItr = data.iterator();
             while (dataItr.hasNext()) {
                 String s = dataItr.next();
-                if (PARENT.equals(s)) {
+                if (PARENT.equals(s)&&p.numSegments()>0) {
                     p.pop();
                 } else if (!THIS.equals(s)) {
                     p.push(s);

--- a/util/src/test/java/com/redhat/lightblue/util/NormalizeTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/NormalizeTest.java
@@ -35,11 +35,7 @@ public class NormalizeTest {
 
     @Test
     public void manyParentTest() {
-        try {
-            new Path("zero.one.$parent.$parent.$parent.three.four").normalize();
-            Assert.fail();
-        } catch (Exception e) {
-        }
+        Assert.assertEquals("$parent.three.four",new Path("zero.one.$parent.$parent.$parent.three.four").normalize().toString());
     }
 
     @Test
@@ -55,5 +51,13 @@ public class NormalizeTest {
     @Test
     public void thisTest2() {
         Assert.assertEquals("zero.one.two.three.four", new Path("$this.zero.one.two.$this.three.$this.four").normalize().toString());
+    }
+    @Test
+    public void normalizeTest() {
+        Assert.assertEquals("x.z",new Path("x.y.$parent.z").normalize().toString());
+        Assert.assertEquals("z",new Path("x.z.$parent.$parent.z").normalize().toString());
+        Assert.assertEquals("$parent.z",new Path("x.z.$parent.$parent.$parent.z").normalize().toString());
+        Assert.assertEquals("z",new Path("x.*.$parent.$parent.z").normalize().toString());
+        Assert.assertEquals("$parent.z",new Path("$parent.z").normalize().toString());
     }
 }

--- a/util/src/test/java/com/redhat/lightblue/util/StringPathTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/StringPathTest.java
@@ -20,6 +20,8 @@ package com.redhat.lightblue.util;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class StringPathTest extends AbstractPathTest<Path> {
 
@@ -40,4 +42,5 @@ public class StringPathTest extends AbstractPathTest<Path> {
         String pathString = createPathString(segments);
         return new Path(pathString);
     }
+
 }


### PR DESCRIPTION
… absolute field names, we now keep field names with their entities, and rewrite queries relative to a node. What used to work still works, what was broken is still broken, but at least now I can fix the broken stuff, namely, reference.*.field=x search