### PR TITLE
resolving merge conflicts for unbounded range

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
@@ -143,6 +143,7 @@ public class CRUDFindRequest implements Serializable {
         if (from != null && to != null) {
             ArrayNode arr = factory.arrayNode();
             arr.add(from);
+            if(to>0)
             arr.add(to);
             node.set("range", arr);
         }
@@ -175,7 +176,7 @@ public class CRUDFindRequest implements Serializable {
                 from = x.asLong();
             }
             x = node.get("to");
-            if (x != null) {
+            if (x != null && x.asLong()>0) {
                 to = x.asLong();
             }
         }

--- a/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
@@ -140,13 +140,15 @@ public class CRUDFindRequest implements Serializable {
         if (sort != null) {
             node.set("sort", sort.toJson());
         }
-        if (from != null && to != null) {
-            ArrayNode arr = factory.arrayNode();
-            arr.add(from);
-            if(to>0)
-            arr.add(to);
-            node.set("range", arr);
-        }
+		if (from != null && to != null) {
+			ArrayNode arr = factory.arrayNode();
+			arr.add(from);
+			if (to > 0)
+				arr.add(to);
+			else
+				arr.addNull();
+			node.set("range", arr);
+		}
     }
 
     /**
@@ -169,6 +171,7 @@ public class CRUDFindRequest implements Serializable {
         x = node.get("range");
         if (x instanceof ArrayNode && ((ArrayNode) x).size() == 2) {
             from = ((ArrayNode) x).get(0).asLong();
+            if(!((ArrayNode) x).get(1).isNull())
             to = ((ArrayNode) x).get(1).asLong();
         } else {
             x = node.get("from");
@@ -176,7 +179,7 @@ public class CRUDFindRequest implements Serializable {
                 from = x.asLong();
             }
             x = node.get("to");
-            if (x != null && x.asLong()>0) {
+            if (x != null) {
                 to = x.asLong();
             }
         }

--- a/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
@@ -143,7 +143,7 @@ public class CRUDFindRequest implements Serializable {
 		if (from != null && to != null) {
 			ArrayNode arr = factory.arrayNode();
 			arr.add(from);
-			if (to > 0)
+			if (to >= 0)
 				arr.add(to);
 			else
 				arr.addNull();
@@ -173,6 +173,8 @@ public class CRUDFindRequest implements Serializable {
             from = ((ArrayNode) x).get(0).asLong();
             if(!((ArrayNode) x).get(1).isNull())
             to = ((ArrayNode) x).get(1).asLong();
+            else
+            	to = null;
         } else {
             x = node.get("from");
             if (x != null) {

--- a/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/CRUDFindRequest.java
@@ -140,10 +140,10 @@ public class CRUDFindRequest implements Serializable {
         if (sort != null) {
             node.set("sort", sort.toJson());
         }
-		if (from != null && to != null) {
+		if (from != null) {
 			ArrayNode arr = factory.arrayNode();
 			arr.add(from);
-			if (to >= 0)
+			if( to != null)
 				arr.add(to);
 			else
 				arr.addNull();

--- a/crud/src/main/java/com/redhat/lightblue/eval/ArrayRangeProjector.java
+++ b/crud/src/main/java/com/redhat/lightblue/eval/ArrayRangeProjector.java
@@ -30,32 +30,45 @@ import com.redhat.lightblue.query.Projection;
  */
 public class ArrayRangeProjector extends ArrayProjector {
 
-    private final int from;
-    private final int to;
+	private final Integer from;
+	private final Integer to;
 
-    /**
-     * Ctor
-     *
-     * @param p The projection expression
-     * @param ctxPath The absolute path relative to which this is to be
-     * interpreted
-     * @param context The metadata node at which this is to be interpreted
-     */
-    public ArrayRangeProjector(ArrayRangeProjection p, Path ctxPath, FieldTreeNode ctx) {
-        super(p, ctxPath, ctx);
-        from = p.getFrom();
-        to = p.getTo();
-    }
+	/**
+	 * Ctor
+	 *
+	 * @param p
+	 *            The projection expression
+	 * @param ctxPath
+	 *            The absolute path relative to which this is to be interpreted
+	 * @param context
+	 *            The metadata node at which this is to be interpreted
+	 */
+	public ArrayRangeProjector(ArrayRangeProjection p, Path ctxPath, FieldTreeNode ctx) {
+		super(p, ctxPath, ctx);
+		from = p.getFrom();
+		to = p.getTo();
+	}
 
-    @Override
-    protected Projection.Inclusion projectArray(Path p, QueryEvaluationContext ctx) {
-        // Is this array element in range?
-        int index = p.getIndex(p.numSegments() - 1);
-        if (index >= from && index <= to) {
-            // This array element is selected.
-            return isIncluded() ? Projection.Inclusion.explicit_inclusion : Projection.Inclusion.explicit_exclusion;
-        } else {
-            return Projection.Inclusion.explicit_exclusion;
-        }
-    }
+	@Override
+	protected Projection.Inclusion projectArray(Path p, QueryEvaluationContext ctx) {
+		// Is this array element in range?
+		int index = p.getIndex(p.numSegments() - 1);
+		if (to == null) {
+			if (index >= from) {
+				// This array element is selected.
+				return isIncluded() ? Projection.Inclusion.explicit_inclusion : Projection.Inclusion.explicit_exclusion;
+			} else {
+				return Projection.Inclusion.explicit_exclusion;
+			}
+		} else if (to < 0) {
+			return Projection.Inclusion.explicit_exclusion;
+		} else {
+			if (from <= to && index >= from && index <= to) {
+				// This array element is selected.
+				return isIncluded() ? Projection.Inclusion.explicit_inclusion : Projection.Inclusion.explicit_exclusion;
+			} else {
+				return Projection.Inclusion.explicit_exclusion;
+			}
+		}
+	}
 }

--- a/crud/src/test/java/com/redhat/lightblue/crud/CRUDFindRequestTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/crud/CRUDFindRequestTest.java
@@ -59,4 +59,25 @@ public class CRUDFindRequestTest extends AbstractJsonNodeTest {
         Assert.assertNull(req.getFrom());
         Assert.assertEquals(200, req.getTo().longValue());
     }
+    
+
+    @Test
+    public void test_zero_to() throws IOException {
+        JsonNode node = loadJsonNode("crud/find/schema-test-find-simple-0-to.json");
+        CRUDFindRequest req = new CRUDFindRequest();
+        req.fromJson((ObjectNode) node);
+
+        Assert.assertNull(req.getFrom());
+        Assert.assertEquals(0, req.getTo().longValue());
+    }
+    
+    @Test
+    public void test_null_to() throws IOException {
+        JsonNode node = loadJsonNode("crud/find/schema-test-find-simple-null-to.json");
+        CRUDFindRequest req = new CRUDFindRequest();
+        req.fromJson((ObjectNode) node);
+
+        Assert.assertEquals(0, req.getFrom().longValue());
+        Assert.assertNull(req.getTo());
+    }
 }

--- a/crud/src/test/java/com/redhat/lightblue/eval/ProjectionTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ProjectionTest.java
@@ -41,381 +41,392 @@ import java.io.IOException;
 
 public class ProjectionTest extends AbstractJsonNodeTest {
 
-    private static final JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(true);
+	private static final JsonNodeFactory factory = JsonNodeFactory.withExactBigDecimals(true);
 
-    private static JsonNode json(String q) {
-        try {
-            return JsonUtils.json(q.replace('\'', '\"'));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
+	private static JsonNode json(String q) {
+		try {
+			return JsonUtils.json(q.replace('\'', '\"'));
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-    private EntityMetadata getMd(String fname) throws Exception {
-        JsonNode node = loadJsonNode(fname);
-        Extensions<JsonNode> extensions = new Extensions<>();
-        extensions.addDefaultExtensions();
-        extensions.registerDataStoreParser("mongo", new TestDataStoreParser<JsonNode>());
-        TypeResolver resolver = new DefaultTypes();
-        JSONMetadataParser parser = new JSONMetadataParser(extensions, resolver, factory);
-        return parser.parseEntityMetadata(node);
-    }
+	private EntityMetadata getMd(String fname) throws Exception {
+		JsonNode node = loadJsonNode(fname);
+		Extensions<JsonNode> extensions = new Extensions<>();
+		extensions.addDefaultExtensions();
+		extensions.registerDataStoreParser("mongo", new TestDataStoreParser<JsonNode>());
+		TypeResolver resolver = new DefaultTypes();
+		JSONMetadataParser parser = new JSONMetadataParser(extensions, resolver, factory);
+		return parser.parseEntityMetadata(node);
+	}
 
-    private JsonDoc getDoc(String fname) throws Exception {
-        JsonNode node = loadJsonNode(fname);
-        return new JsonDoc(node);
-    }
+	private JsonDoc getDoc(String fname) throws Exception {
+		JsonNode node = loadJsonNode(fname);
+		return new JsonDoc(node);
+	}
 
-    private Projector projector(String str, EntityMetadata md) {
-        Projection p = Projection.fromJson(json(str));
-        return Projector.getInstance(p, md);
-    }
+	private Projector projector(String str, EntityMetadata md) {
+		Projection p = Projection.fromJson(json(str));
+		return Projector.getInstance(p, md);
+	}
 
-    @Test
-    public void basicProjectionTest() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "{'field':'*','include':1}";
-        Projector projector = projector(pr, md);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertEquals("test", newDoc.get(new Path("objectType")).asText());
-        Assert.assertEquals("value1", newDoc.get(new Path("field1")).asText());
-        Assert.assertEquals("value2", newDoc.get(new Path("field2")).asText());
-        Assert.assertEquals(3, newDoc.get(new Path("field3")).asInt());
-        Assert.assertEquals(4.0, newDoc.get(new Path("field4")).asDouble(), 0.001);
-        Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
-        Assert.assertNull(newDoc.get(new Path("field6")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf1")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf2")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf3")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf4")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf5")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf6")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf7")));
-        Assert.assertNull(newDoc.get(new Path("field7")));
-        Assert.assertNull(newDoc.get(new Path("field7")));
-    }
+	@Test
+	public void basicProjectionTest() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'*','include':1}";
+		Projector projector = projector(pr, md);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertEquals("test", newDoc.get(new Path("objectType")).asText());
+		Assert.assertEquals("value1", newDoc.get(new Path("field1")).asText());
+		Assert.assertEquals("value2", newDoc.get(new Path("field2")).asText());
+		Assert.assertEquals(3, newDoc.get(new Path("field3")).asInt());
+		Assert.assertEquals(4.0, newDoc.get(new Path("field4")).asDouble(), 0.001);
+		Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
+		Assert.assertNull(newDoc.get(new Path("field6")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf1")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf2")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf3")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf4")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf5")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf6")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf7")));
+		Assert.assertNull(newDoc.get(new Path("field7")));
+		Assert.assertNull(newDoc.get(new Path("field7")));
+	}
 
-    @Test
-    public void basicProjectionTest_recursive() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "{'field':'*','include':1,'recursive':1}";
-        Projector projector = projector(pr, md);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertEquals("test", newDoc.get(new Path("objectType")).asText());
-        Assert.assertEquals("value1", newDoc.get(new Path("field1")).asText());
-        Assert.assertEquals("value2", newDoc.get(new Path("field2")).asText());
-        Assert.assertEquals(3, newDoc.get(new Path("field3")).asInt());
-        Assert.assertEquals(4.0, newDoc.get(new Path("field4")).asDouble(), 0.001);
-        Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
-        Assert.assertNotNull(newDoc.get(new Path("field6")));
-        Assert.assertEquals("nvalue1", newDoc.get(new Path("field6.nf1")).asText());
-        Assert.assertEquals("nvalue2", newDoc.get(new Path("field6.nf2")).asText());
-        Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
-        Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
-        Assert.assertEquals(5, newDoc.get(new Path("field6.nf5.0")).asInt());
-        Assert.assertEquals(10, newDoc.get(new Path("field6.nf5.1")).asInt());
-        Assert.assertEquals(15, newDoc.get(new Path("field6.nf5.2")).asInt());
-        Assert.assertEquals(20, newDoc.get(new Path("field6.nf5.3")).asInt());
-        Assert.assertEquals("one", newDoc.get(new Path("field6.nf6.0")).asText());
-        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.1")).asText());
-        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.2")).asText());
-        Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.3")).asText());
-        Assert.assertEquals("nnvalue1", newDoc.get(new Path("field6.nf7.nnf1")).asText());
-        Assert.assertEquals(2, newDoc.get(new Path("field6.nf7.nnf2")).asInt());
-        Assert.assertEquals(4, newDoc.get(new Path("field7")).size());
-        Assert.assertEquals("elvalue0_1", newDoc.get(new Path("field7.0.elemf1")).asText());
-        Assert.assertEquals("elvalue1_1", newDoc.get(new Path("field7.1.elemf1")).asText());
-        Assert.assertEquals("elvalue2_1", newDoc.get(new Path("field7.2.elemf1")).asText());
-        Assert.assertEquals("elvalue3_1", newDoc.get(new Path("field7.3.elemf1")).asText());
-    }
+	@Test
+	public void basicProjectionTest_recursive() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'*','include':1,'recursive':1}";
+		Projector projector = projector(pr, md);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertEquals("test", newDoc.get(new Path("objectType")).asText());
+		Assert.assertEquals("value1", newDoc.get(new Path("field1")).asText());
+		Assert.assertEquals("value2", newDoc.get(new Path("field2")).asText());
+		Assert.assertEquals(3, newDoc.get(new Path("field3")).asInt());
+		Assert.assertEquals(4.0, newDoc.get(new Path("field4")).asDouble(), 0.001);
+		Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
+		Assert.assertNotNull(newDoc.get(new Path("field6")));
+		Assert.assertEquals("nvalue1", newDoc.get(new Path("field6.nf1")).asText());
+		Assert.assertEquals("nvalue2", newDoc.get(new Path("field6.nf2")).asText());
+		Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
+		Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
+		Assert.assertEquals(5, newDoc.get(new Path("field6.nf5.0")).asInt());
+		Assert.assertEquals(10, newDoc.get(new Path("field6.nf5.1")).asInt());
+		Assert.assertEquals(15, newDoc.get(new Path("field6.nf5.2")).asInt());
+		Assert.assertEquals(20, newDoc.get(new Path("field6.nf5.3")).asInt());
+		Assert.assertEquals("one", newDoc.get(new Path("field6.nf6.0")).asText());
+		Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.1")).asText());
+		Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.2")).asText());
+		Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.3")).asText());
+		Assert.assertEquals("nnvalue1", newDoc.get(new Path("field6.nf7.nnf1")).asText());
+		Assert.assertEquals(2, newDoc.get(new Path("field6.nf7.nnf2")).asInt());
+		Assert.assertEquals(4, newDoc.get(new Path("field7")).size());
+		Assert.assertEquals("elvalue0_1", newDoc.get(new Path("field7.0.elemf1")).asText());
+		Assert.assertEquals("elvalue1_1", newDoc.get(new Path("field7.1.elemf1")).asText());
+		Assert.assertEquals("elvalue2_1", newDoc.get(new Path("field7.2.elemf1")).asText());
+		Assert.assertEquals("elvalue3_1", newDoc.get(new Path("field7.3.elemf1")).asText());
+	}
 
-    @Test
-    public void basicProjectionTest_exclusion() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "[{'field':'*','include':1,'recursive':1},{'field':'field7','include':0}]";
-        Projector projector = projector(pr, md);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertEquals("test", newDoc.get(new Path("objectType")).asText());
-        Assert.assertEquals("value1", newDoc.get(new Path("field1")).asText());
-        Assert.assertEquals("value2", newDoc.get(new Path("field2")).asText());
-        Assert.assertEquals(3, newDoc.get(new Path("field3")).asInt());
-        Assert.assertEquals(4.0, newDoc.get(new Path("field4")).asDouble(), 0.001);
-        Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
-        Assert.assertNotNull(newDoc.get(new Path("field6")));
-        Assert.assertEquals("nvalue1", newDoc.get(new Path("field6.nf1")).asText());
-        Assert.assertEquals("nvalue2", newDoc.get(new Path("field6.nf2")).asText());
-        Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
-        Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
-        Assert.assertEquals(5, newDoc.get(new Path("field6.nf5.0")).asInt());
-        Assert.assertEquals(10, newDoc.get(new Path("field6.nf5.1")).asInt());
-        Assert.assertEquals(15, newDoc.get(new Path("field6.nf5.2")).asInt());
-        Assert.assertEquals(20, newDoc.get(new Path("field6.nf5.3")).asInt());
-        Assert.assertEquals("one", newDoc.get(new Path("field6.nf6.0")).asText());
-        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.1")).asText());
-        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.2")).asText());
-        Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.3")).asText());
-        Assert.assertEquals("nnvalue1", newDoc.get(new Path("field6.nf7.nnf1")).asText());
-        Assert.assertEquals(2, newDoc.get(new Path("field6.nf7.nnf2")).asInt());
-        Assert.assertNull(newDoc.get(new Path("field7")));
-    }
+	@Test
+	public void basicProjectionTest_exclusion() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "[{'field':'*','include':1,'recursive':1},{'field':'field7','include':0}]";
+		Projector projector = projector(pr, md);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertEquals("test", newDoc.get(new Path("objectType")).asText());
+		Assert.assertEquals("value1", newDoc.get(new Path("field1")).asText());
+		Assert.assertEquals("value2", newDoc.get(new Path("field2")).asText());
+		Assert.assertEquals(3, newDoc.get(new Path("field3")).asInt());
+		Assert.assertEquals(4.0, newDoc.get(new Path("field4")).asDouble(), 0.001);
+		Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
+		Assert.assertNotNull(newDoc.get(new Path("field6")));
+		Assert.assertEquals("nvalue1", newDoc.get(new Path("field6.nf1")).asText());
+		Assert.assertEquals("nvalue2", newDoc.get(new Path("field6.nf2")).asText());
+		Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
+		Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
+		Assert.assertEquals(5, newDoc.get(new Path("field6.nf5.0")).asInt());
+		Assert.assertEquals(10, newDoc.get(new Path("field6.nf5.1")).asInt());
+		Assert.assertEquals(15, newDoc.get(new Path("field6.nf5.2")).asInt());
+		Assert.assertEquals(20, newDoc.get(new Path("field6.nf5.3")).asInt());
+		Assert.assertEquals("one", newDoc.get(new Path("field6.nf6.0")).asText());
+		Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.1")).asText());
+		Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.2")).asText());
+		Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.3")).asText());
+		Assert.assertEquals("nnvalue1", newDoc.get(new Path("field6.nf7.nnf1")).asText());
+		Assert.assertEquals(2, newDoc.get(new Path("field6.nf7.nnf2")).asInt());
+		Assert.assertNull(newDoc.get(new Path("field7")));
+	}
 
-    @Test
-    public void projectionListTest() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "[{'field':'field6.*','include':1},{'field':'field5'}]";
-        Projector projector = projector(pr, md);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("field2")));
-        Assert.assertNull(newDoc.get(new Path("field3")));
-        Assert.assertNull(newDoc.get(new Path("field4")));
-        Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
-        Assert.assertNotNull(newDoc.get(new Path("field6")));
-        Assert.assertEquals("nvalue1", newDoc.get(new Path("field6.nf1")).asText());
-        Assert.assertEquals("nvalue2", newDoc.get(new Path("field6.nf2")).asText());
-        Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
-        Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
-        Assert.assertNull(newDoc.get(new Path("field6.nf5")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf6")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf7")));
-        Assert.assertNull(newDoc.get(new Path("field7")));
-    }
+	@Test
+	public void projectionListTest() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "[{'field':'field6.*','include':1},{'field':'field5'}]";
+		Projector projector = projector(pr, md);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("field2")));
+		Assert.assertNull(newDoc.get(new Path("field3")));
+		Assert.assertNull(newDoc.get(new Path("field4")));
+		Assert.assertEquals(true, newDoc.get(new Path("field5")).asBoolean());
+		Assert.assertNotNull(newDoc.get(new Path("field6")));
+		Assert.assertEquals("nvalue1", newDoc.get(new Path("field6.nf1")).asText());
+		Assert.assertEquals("nvalue2", newDoc.get(new Path("field6.nf2")).asText());
+		Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
+		Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
+		Assert.assertNull(newDoc.get(new Path("field6.nf5")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf6")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf7")));
+		Assert.assertNull(newDoc.get(new Path("field7")));
+	}
 
-    @Test
-    public void arrayRangeTest() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "{'field':'field6.nf6','range':[1,2],'project':{'field':'*'}}";
-        Projector projector = projector(pr, md);
-        System.out.println(projector.toString());
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("field2")));
-        Assert.assertNull(newDoc.get(new Path("field3")));
-        Assert.assertNull(newDoc.get(new Path("field4")));
-        Assert.assertNull(newDoc.get(new Path("field5")));
-        Assert.assertNotNull(newDoc.get(new Path("field6")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf1")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf2")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf3")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf4")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf5")));
-        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
-        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
-        Assert.assertEquals(2, newDoc.get(new Path("field6.nf6")).size());
-        Assert.assertNull(newDoc.get(new Path("field6.nf7")));
-        Assert.assertNull(newDoc.get(new Path("field7")));
-    }
-    
-    @Test
-    public void arrayRangeTest_Projection() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "{'field':'field6.nf6','range':[1,2],'projection':{'field':'*'}}";
-        Projector projector = projector(pr, md);
-        System.out.println(projector.toString());
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("field2")));
-        Assert.assertNull(newDoc.get(new Path("field3")));
-        Assert.assertNull(newDoc.get(new Path("field4")));
-        Assert.assertNull(newDoc.get(new Path("field5")));
-        Assert.assertNotNull(newDoc.get(new Path("field6")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf1")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf2")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf3")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf4")));
-        Assert.assertNull(newDoc.get(new Path("field6.nf5")));
-        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
-        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
-        Assert.assertEquals(2, newDoc.get(new Path("field6.nf6")).size());
-        Assert.assertNull(newDoc.get(new Path("field6.nf7")));
-        Assert.assertNull(newDoc.get(new Path("field7")));
-    }
-    
-    @Test
-    public void arrayRangeTestForZeroUpperBound() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "{'field':'field6.nf6','range':[1,0],'projection':{'field':'*'}}";
-        Projector projector = projector(pr, md);
-        System.out.println(projector.toString());
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNotNull(newDoc.get(new Path("field6")));
-        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
-        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
-        Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.2")).asText());
-        Assert.assertEquals(3, newDoc.get(new Path("field6.nf6")).size());
-    }
-    
-    @Test
-    public void arrayRangeTestForNegativeUpperBound() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "{'field':'field6.nf6','range':[1,-8],'projection':{'field':'*'}}";
-        Projector projector = projector(pr, md);
-        System.out.println(projector.toString());
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNotNull(newDoc.get(new Path("field6")));
-        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
-        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
-        Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.2")).asText());
-        Assert.assertEquals(3, newDoc.get(new Path("field6.nf6")).size());
-    }
+	@Test
+	public void arrayRangeTest() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'field6.nf6','range':[1,2],'project':{'field':'*'}}";
+		Projector projector = projector(pr, md);
+		System.out.println(projector.toString());
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("field2")));
+		Assert.assertNull(newDoc.get(new Path("field3")));
+		Assert.assertNull(newDoc.get(new Path("field4")));
+		Assert.assertNull(newDoc.get(new Path("field5")));
+		Assert.assertNotNull(newDoc.get(new Path("field6")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf1")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf2")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf3")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf4")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf5")));
+		Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
+		Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
+		Assert.assertEquals(2, newDoc.get(new Path("field6.nf6")).size());
+		Assert.assertNull(newDoc.get(new Path("field6.nf7")));
+		Assert.assertNull(newDoc.get(new Path("field7")));
+	}
 
+	@Test
+	public void arrayRangeTest_Projection() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'field6.nf6','range':[1,2],'projection':{'field':'*'}}";
+		Projector projector = projector(pr, md);
+		System.out.println(projector.toString());
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("field2")));
+		Assert.assertNull(newDoc.get(new Path("field3")));
+		Assert.assertNull(newDoc.get(new Path("field4")));
+		Assert.assertNull(newDoc.get(new Path("field5")));
+		Assert.assertNotNull(newDoc.get(new Path("field6")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf1")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf2")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf3")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf4")));
+		Assert.assertNull(newDoc.get(new Path("field6.nf5")));
+		Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
+		Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
+		Assert.assertEquals(2, newDoc.get(new Path("field6.nf6")).size());
+		Assert.assertNull(newDoc.get(new Path("field6.nf7")));
+		Assert.assertNull(newDoc.get(new Path("field7")));
+	}
 
-    @Test
-    public void arrayNestedQTest() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-        JsonDoc doc = getDoc("./sample1.json");
-        String pr = "{'field':'field7','match':{'field':'elemf1','op':'$eq','rvalue':'elvalue0_1'}}";
-        Projector projector = projector(pr, md);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("field2")));
-        Assert.assertNull(newDoc.get(new Path("field3")));
-        Assert.assertNull(newDoc.get(new Path("field4")));
-        Assert.assertNull(newDoc.get(new Path("field5")));
-        Assert.assertNull(newDoc.get(new Path("field6")));
-        Assert.assertNotNull(newDoc.get(new Path("field7")));
-        Assert.assertEquals(1, newDoc.get(new Path("field7")).size());
-        Assert.assertEquals("elvalue0_1", newDoc.get(new Path("field7.0.elemf1")).asText());
-    }
+	@Test
+	public void arrayRangeTestForZeroUpperBound() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'field6.nf6','range':[1,0],'projection':{'field':'*'}}";
+		Projector projector = projector(pr, md);
+		System.out.println(projector.toString());
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("field6")));
+	}
 
-    private class SimpleGMD implements CompositeMetadata.GetMetadata {
-        public EntityMetadata getMetadata(Path injectionField,
-                                          String entityName,
-                                          String version) {
-            try {
-                return getMd("composite/"+entityName+".json");
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
+	@Test
+	public void arrayRangeTestForNegativeUpperBound() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'field6.nf6','range':[1,-8],'projection':{'field':'*'}}";
+		Projector projector = projector(pr, md);
+		System.out.println(projector.toString());
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("field6")));
+	}
 
-    // This test is no longer valid. Projection evaluation don't care entity boundaries. 
-    // Composite metadata construction interprets the projections, and constructs
-    // the tree excluding unprojected entities. 
-    @Test
-    @Ignore
-    public void recursiveInclusionsDontCrossEntityBoundaries() throws Exception {
-        EntityMetadata md=getMd("./composite/A.json");
-        CompositeMetadata cmd=CompositeMetadata.buildCompositeMetadata(md,new SimpleGMD());
-        JsonDoc doc=getDoc("./composite/doc1.json");
+	@Test
+	public void arrayRangeTestForZeroZeroBounds() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'field6.nf6','range':[0,0],'projection':{'field':'*'}}";
+		Projector projector = projector(pr, md);
+		System.out.println(projector.toString());
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNotNull(newDoc.get(new Path("field6")));
+		Assert.assertEquals("one", newDoc.get(new Path("field6.nf6.0")).asText());
+		Assert.assertEquals(1, newDoc.get(new Path("field6.nf6")).size());
+	}
 
-        String pr="{'field':'obj1','include':1,'recursive':1}";
-        Projector projector = projector(pr, cmd);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
+	@Test
+	public void arrayNestedQTest() throws Exception {
+		EntityMetadata md = getMd("./testMetadata.json");
+		JsonDoc doc = getDoc("./sample1.json");
+		String pr = "{'field':'field7','match':{'field':'elemf1','op':'$eq','rvalue':'elvalue0_1'}}";
+		Projector projector = projector(pr, md);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("field2")));
+		Assert.assertNull(newDoc.get(new Path("field3")));
+		Assert.assertNull(newDoc.get(new Path("field4")));
+		Assert.assertNull(newDoc.get(new Path("field5")));
+		Assert.assertNull(newDoc.get(new Path("field6")));
+		Assert.assertNotNull(newDoc.get(new Path("field7")));
+		Assert.assertEquals(1, newDoc.get(new Path("field7")).size());
+		Assert.assertEquals("elvalue0_1", newDoc.get(new Path("field7.0.elemf1")).asText());
+	}
 
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("b")));
-        Assert.assertNull(newDoc.get(new Path("b_ref")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.field1")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c_ref")));
-        Assert.assertNull(newDoc.get(new Path("obj1.c")));
-    }
+	private class SimpleGMD implements CompositeMetadata.GetMetadata {
+		public EntityMetadata getMetadata(Path injectionField, String entityName, String version) {
+			try {
+				return getMd("composite/" + entityName + ".json");
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
 
-    // This test is no longer valid. Projection evaluation don't care entity boundaries. 
-    // Composite metadata construction interprets the projections, and constructs
-    // the tree excluding unprojected entities. 
-    @Test
-    @Ignore
-    public void explicitInclusionByPatternCrossesEntityBoundaries() throws Exception {
-        EntityMetadata md=getMd("./composite/A.json");
-        CompositeMetadata cmd=CompositeMetadata.buildCompositeMetadata(md,new SimpleGMD());
-        JsonDoc doc=getDoc("./composite/doc1.json");
+	// This test is no longer valid. Projection evaluation don't care entity
+	// boundaries.
+	// Composite metadata construction interprets the projections, and
+	// constructs
+	// the tree excluding unprojected entities.
+	@Test
+	@Ignore
+	public void recursiveInclusionsDontCrossEntityBoundaries() throws Exception {
+		EntityMetadata md = getMd("./composite/A.json");
+		CompositeMetadata cmd = CompositeMetadata.buildCompositeMetadata(md, new SimpleGMD());
+		JsonDoc doc = getDoc("./composite/doc1.json");
 
-        String pr="{'field':'obj1.*','include':1,'recursive':1}";
-        Projector projector = projector(pr, cmd);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("b")));
-        Assert.assertNull(newDoc.get(new Path("b_ref")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.field1")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c_ref")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c")));
-        Assert.assertEquals(2,newDoc.get(new Path("obj1.c")).size());
-   }
+		String pr = "{'field':'obj1','include':1,'recursive':1}";
+		Projector projector = projector(pr, cmd);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
 
-    // This test is no longer valid. Projection evaluation don't care entity boundaries. 
-    // Composite metadata construction interprets the projections, and constructs
-    // the tree excluding unprojected entities. 
-    @Test
-    @Ignore
-    public void explicitInclusionCrossesEntityBoundaries() throws Exception {
-        EntityMetadata md=getMd("./composite/A.json");
-        CompositeMetadata cmd=CompositeMetadata.buildCompositeMetadata(md,new SimpleGMD());
-        JsonDoc doc=getDoc("./composite/doc1.json");
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("b")));
+		Assert.assertNull(newDoc.get(new Path("b_ref")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.field1")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c_ref")));
+		Assert.assertNull(newDoc.get(new Path("obj1.c")));
+	}
 
-        String pr="{'field':'obj1.c','include':1,'recursive':1}";
-        Projector projector = projector(pr, cmd);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("b")));
-        Assert.assertNull(newDoc.get(new Path("b_ref")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1")));
-        Assert.assertNull(newDoc.get(new Path("obj1.field1")));
-        Assert.assertNull(newDoc.get(new Path("obj1.c_ref")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c")));
-        Assert.assertEquals(2,newDoc.get(new Path("obj1.c")).size());
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c.0._id")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c.1._id")));
-        Assert.assertNull(newDoc.get(new Path("obj1.c.0.obj1.d")));
-        Assert.assertNull(newDoc.get(new Path("obj1.c.1.obj1.d")));
-   }
+	// This test is no longer valid. Projection evaluation don't care entity
+	// boundaries.
+	// Composite metadata construction interprets the projections, and
+	// constructs
+	// the tree excluding unprojected entities.
+	@Test
+	@Ignore
+	public void explicitInclusionByPatternCrossesEntityBoundaries() throws Exception {
+		EntityMetadata md = getMd("./composite/A.json");
+		CompositeMetadata cmd = CompositeMetadata.buildCompositeMetadata(md, new SimpleGMD());
+		JsonDoc doc = getDoc("./composite/doc1.json");
 
-    // This test is no longer valid. Projection evaluation don't care entity boundaries. 
-    // Composite metadata construction interprets the projections, and constructs
-    // the tree excluding unprojected entities. 
-    @Test
-    @Ignore
-    public void arrayInclusionIncludesEntity() throws Exception {
-        EntityMetadata md=getMd("./composite/A.json");
-        CompositeMetadata cmd=CompositeMetadata.buildCompositeMetadata(md,new SimpleGMD());
-        JsonDoc doc=getDoc("./composite/doc1.json");
+		String pr = "{'field':'obj1.*','include':1,'recursive':1}";
+		Projector projector = projector(pr, cmd);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("b")));
+		Assert.assertNull(newDoc.get(new Path("b_ref")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.field1")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c_ref")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c")));
+		Assert.assertEquals(2, newDoc.get(new Path("obj1.c")).size());
+	}
 
-        String pr="{'field':'obj1.c','range':[0,1],'project':{'field':'*','include':1,'recursive':1}}";
-        Projector projector = projector(pr, cmd);
-        JsonDoc newDoc = projector.project(doc, factory);
-        System.out.println(pr + ":" + newDoc.getRoot());
-        Assert.assertNull(newDoc.get(new Path("objectType")));
-        Assert.assertNull(newDoc.get(new Path("field1")));
-        Assert.assertNull(newDoc.get(new Path("b")));
-        Assert.assertNull(newDoc.get(new Path("b_ref")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1")));
-        Assert.assertNull(newDoc.get(new Path("obj1.field1")));
-        Assert.assertNull(newDoc.get(new Path("obj1.c_ref")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c")));
-        Assert.assertEquals(2,newDoc.get(new Path("obj1.c")).size());
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c.0._id")));
-        Assert.assertNotNull(newDoc.get(new Path("obj1.c.1._id")));
-        Assert.assertNull(newDoc.get(new Path("obj1.c.0.obj1.d")));
-        Assert.assertNull(newDoc.get(new Path("obj1.c.1.obj1.d")));
-    }
- }
+	// This test is no longer valid. Projection evaluation don't care entity
+	// boundaries.
+	// Composite metadata construction interprets the projections, and
+	// constructs
+	// the tree excluding unprojected entities.
+	@Test
+	@Ignore
+	public void explicitInclusionCrossesEntityBoundaries() throws Exception {
+		EntityMetadata md = getMd("./composite/A.json");
+		CompositeMetadata cmd = CompositeMetadata.buildCompositeMetadata(md, new SimpleGMD());
+		JsonDoc doc = getDoc("./composite/doc1.json");
+
+		String pr = "{'field':'obj1.c','include':1,'recursive':1}";
+		Projector projector = projector(pr, cmd);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("b")));
+		Assert.assertNull(newDoc.get(new Path("b_ref")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1")));
+		Assert.assertNull(newDoc.get(new Path("obj1.field1")));
+		Assert.assertNull(newDoc.get(new Path("obj1.c_ref")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c")));
+		Assert.assertEquals(2, newDoc.get(new Path("obj1.c")).size());
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c.0._id")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c.1._id")));
+		Assert.assertNull(newDoc.get(new Path("obj1.c.0.obj1.d")));
+		Assert.assertNull(newDoc.get(new Path("obj1.c.1.obj1.d")));
+	}
+
+	// This test is no longer valid. Projection evaluation don't care entity
+	// boundaries.
+	// Composite metadata construction interprets the projections, and
+	// constructs
+	// the tree excluding unprojected entities.
+	@Test
+	@Ignore
+	public void arrayInclusionIncludesEntity() throws Exception {
+		EntityMetadata md = getMd("./composite/A.json");
+		CompositeMetadata cmd = CompositeMetadata.buildCompositeMetadata(md, new SimpleGMD());
+		JsonDoc doc = getDoc("./composite/doc1.json");
+
+		String pr = "{'field':'obj1.c','range':[0,1],'project':{'field':'*','include':1,'recursive':1}}";
+		Projector projector = projector(pr, cmd);
+		JsonDoc newDoc = projector.project(doc, factory);
+		System.out.println(pr + ":" + newDoc.getRoot());
+		Assert.assertNull(newDoc.get(new Path("objectType")));
+		Assert.assertNull(newDoc.get(new Path("field1")));
+		Assert.assertNull(newDoc.get(new Path("b")));
+		Assert.assertNull(newDoc.get(new Path("b_ref")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1")));
+		Assert.assertNull(newDoc.get(new Path("obj1.field1")));
+		Assert.assertNull(newDoc.get(new Path("obj1.c_ref")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c")));
+		Assert.assertEquals(2, newDoc.get(new Path("obj1.c")).size());
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c.0._id")));
+		Assert.assertNotNull(newDoc.get(new Path("obj1.c.1._id")));
+		Assert.assertNull(newDoc.get(new Path("obj1.c.0.obj1.d")));
+		Assert.assertNull(newDoc.get(new Path("obj1.c.1.obj1.d")));
+	}
+}

--- a/crud/src/test/java/com/redhat/lightblue/eval/ProjectionTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ProjectionTest.java
@@ -245,6 +245,38 @@ public class ProjectionTest extends AbstractJsonNodeTest {
         Assert.assertNull(newDoc.get(new Path("field6.nf7")));
         Assert.assertNull(newDoc.get(new Path("field7")));
     }
+    
+    @Test
+    public void arrayRangeTestForZeroUpperBound() throws Exception {
+        EntityMetadata md = getMd("./testMetadata.json");
+        JsonDoc doc = getDoc("./sample1.json");
+        String pr = "{'field':'field6.nf6','range':[1,0],'projection':{'field':'*'}}";
+        Projector projector = projector(pr, md);
+        System.out.println(projector.toString());
+        JsonDoc newDoc = projector.project(doc, factory);
+        System.out.println(pr + ":" + newDoc.getRoot());
+        Assert.assertNotNull(newDoc.get(new Path("field6")));
+        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
+        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
+        Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.2")).asText());
+        Assert.assertEquals(3, newDoc.get(new Path("field6.nf6")).size());
+    }
+    
+    @Test
+    public void arrayRangeTestForNegativeUpperBound() throws Exception {
+        EntityMetadata md = getMd("./testMetadata.json");
+        JsonDoc doc = getDoc("./sample1.json");
+        String pr = "{'field':'field6.nf6','range':[1,-8],'projection':{'field':'*'}}";
+        Projector projector = projector(pr, md);
+        System.out.println(projector.toString());
+        JsonDoc newDoc = projector.project(doc, factory);
+        System.out.println(pr + ":" + newDoc.getRoot());
+        Assert.assertNotNull(newDoc.get(new Path("field6")));
+        Assert.assertEquals("two", newDoc.get(new Path("field6.nf6.0")).asText());
+        Assert.assertEquals("three", newDoc.get(new Path("field6.nf6.1")).asText());
+        Assert.assertEquals("four", newDoc.get(new Path("field6.nf6.2")).asText());
+        Assert.assertEquals(3, newDoc.get(new Path("field6.nf6")).size());
+    }
 
 
     @Test

--- a/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
@@ -113,6 +113,59 @@ public class ProjectorTest extends AbstractJsonNodeTest {
         Assert.assertNull(pdoc.get(new Path("field7.1.elemf2")));
 
     }
+    
+    @Test
+	public void fieldProjectorTest_arr_range_zero_zero_bounds() throws Exception {
+
+		Projection p = EvalTestContext
+				.projectionFromJson("{'field':'field7','range':[0,0],'projection':{'field':'elemf3'}}");
+		Projector projector = Projector.getInstance(p, md);
+		JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
+		Assert.assertEquals(1, pdoc.get(new Path("field7")).size());
+		Assert.assertEquals(3, pdoc.get(new Path("field7.0.elemf3")).asInt());
+	}
+
+	@Test
+	public void fieldProjectorTest_arr_range_zero_upper_bound() throws Exception {
+		Projection p = EvalTestContext
+				.projectionFromJson("{'field':'field7','range':[1,0],'projection':{'field':'elemf3'}}");
+		Projector projector = Projector.getInstance(p, md);
+		JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
+		Assert.assertNull(pdoc.get(new Path("field7")));
+
+	}
+
+	@Test
+	public void fieldProjectorTest_arr_range_to_gt_from() throws Exception {
+		Projection p = EvalTestContext
+				.projectionFromJson("{'field':'field7','range':[3,1],'projection':{'field':'elemf3'}}");
+		Projector projector = Projector.getInstance(p, md);
+		JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
+		Assert.assertNull(pdoc.get(new Path("field7")));
+
+	}
+
+	@Test
+	public void fieldProjectorTest_arr_range_negative_upper_bound() throws Exception {
+		Projection p = EvalTestContext
+				.projectionFromJson("{'field':'field7','range':[1,-8],'projection':{'field':'elemf3'}}");
+		Projector projector = Projector.getInstance(p, md);
+		JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
+		Assert.assertNull(pdoc.get(new Path("field7")));
+	}
+
+	@Test
+	public void fieldProjectorTest_arr_range_null_upper_bound() throws Exception {
+		Projection p = EvalTestContext
+				.projectionFromJson("{'field':'field7','range':[1,null],'projection':{'field':'elemf3'}}");
+		Projector projector = Projector.getInstance(p, md);
+		JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
+		Assert.assertEquals(3, pdoc.get(new Path("field7")).size());
+		Assert.assertEquals(4, pdoc.get(new Path("field7.0.elemf3")).asInt());
+		Assert.assertEquals(5, pdoc.get(new Path("field7.1.elemf3")).asInt());
+		Assert.assertEquals(6, pdoc.get(new Path("field7.2.elemf3")).asInt());
+
+	}
 
     @Test
     public void fieldProjectorTest_arr_query() throws Exception {
@@ -359,4 +412,4 @@ public class ProjectorTest extends AbstractJsonNodeTest {
         Assert.assertNull(pdoc.get(new Path("field6")));
         Assert.assertNull(pdoc.get(new Path("field6.nf5")));
     }
-}
+	}

--- a/crud/src/test/resources/crud/find/schema-test-find-simple-0-to.json
+++ b/crud/src/test/resources/crud/find/schema-test-find-simple-0-to.json
@@ -1,0 +1,22 @@
+{
+        "objectType": "some_entity",
+        "client": {"id": "1"},
+        "execution": {
+            "timeLimit": 5000,
+            "asynchronous": 4500
+        },
+        "projection": {
+            "field": "firstname",
+            "include": true,
+            "recursive": true
+        },
+        "query": {
+            "field": "login",
+            "op": "$eq",
+            "rfield": "someuser"
+        },
+        "to": 0,
+        "sort": {
+            "login": "$asc"
+        }
+ }

--- a/crud/src/test/resources/crud/find/schema-test-find-simple-null-to.json
+++ b/crud/src/test/resources/crud/find/schema-test-find-simple-null-to.json
@@ -1,0 +1,25 @@
+{
+        "objectType": "some_entity",
+        "client": {"id": "1"},
+        "execution": {
+            "timeLimit": 5000,
+            "asynchronous": 4500
+        },
+        "projection": {
+            "field": "firstname",
+            "include": true,
+            "recursive": true
+        },
+        "query": {
+            "field": "login",
+            "op": "$eq",
+            "rfield": "someuser"
+        },
+      "range": [
+            0,
+            null
+        ],
+        "sort": {
+            "login": "$asc"
+        }
+ }

--- a/query-api/src/main/java/com/redhat/lightblue/query/ArrayRangeProjection.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/ArrayRangeProjection.java
@@ -45,16 +45,27 @@ public class ArrayRangeProjection extends ArrayProjection {
 	}
 
 	public Integer getTo() {
-		if (to == null) {
-			return null;
-		} else
-			return this.to;
+		return this.to;
 	}
 
 	@Override
 	public JsonNode toJson() {
 		ArrayNode arr = getFactory().arrayNode();
-		arr.add(getFactory().numberNode(from)).add(getFactory().numberNode(to));
+		if (from == null) {
+			arr.add(getFactory().nullNode());
+			if (to == null) {
+				arr.add(getFactory().nullNode());
+			} else {
+				arr.add(getFactory().numberNode(to));
+			}
+		} else if (from != null) {
+			arr.add(getFactory().numberNode(from));
+			if (to == null) {
+				arr.add(getFactory().nullNode());
+			} else {
+				arr.add(getFactory().numberNode(to));
+			}
+		}
 		return ((ObjectNode) super.toJson()).set("range", arr);
 	}
 }

--- a/query-api/src/main/java/com/redhat/lightblue/query/ArrayRangeProjection.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/ArrayRangeProjection.java
@@ -25,43 +25,36 @@ import com.redhat.lightblue.util.Path;
 
 public class ArrayRangeProjection extends ArrayProjection {
 
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    private final int from;
-    private final int to;
+	private final Integer from;
+	private final Integer to;
 
-    public ArrayRangeProjection(Path field,
-                                boolean include,
-                                Projection project,
-                                Sort sort,
-                                int from,
-                                int to) {
-        super(field, include, project, sort);
-        this.from = from;
-        this.to = to;
-    }
+	public ArrayRangeProjection(Path field, boolean include, Projection project, Sort sort, Integer from, Integer to) {
+		super(field, include, project, sort);
+		this.from = from;
+		this.to = to;
+	}
 
-    public ArrayRangeProjection(Path field,
-                                boolean include,
-                                Projection project,
-                                int from,
-                                int to) {
-        this(field, include, project, null, from, to);
-    }
+	public ArrayRangeProjection(Path field, boolean include, Projection project, Integer from, Integer to) {
+		this(field, include, project, null, from, to);
+	}
 
-    public int getFrom() {
-        return this.from;
-    }
+	public Integer getFrom() {
+		return this.from;
+	}
 
-    public int getTo() {
-        return this.to;
-    }
+	public Integer getTo() {
+		if (to == null) {
+			return null;
+		} else
+			return this.to;
+	}
 
-    @Override
-    public JsonNode toJson() {
-        ArrayNode arr = getFactory().arrayNode();
-        arr.add(getFactory().numberNode(from)).
-                add(getFactory().numberNode(to));
-        return ((ObjectNode) super.toJson()).set("range", arr);
-    }
+	@Override
+	public JsonNode toJson() {
+		ArrayNode arr = getFactory().arrayNode();
+		arr.add(getFactory().numberNode(from)).add(getFactory().numberNode(to));
+		return ((ObjectNode) super.toJson()).set("range", arr);
+	}
 }

--- a/query-api/src/main/java/com/redhat/lightblue/query/BasicProjection.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/BasicProjection.java
@@ -78,8 +78,12 @@ public abstract class BasicProjection extends Projection {
         if (x != null) {
             if (x instanceof ArrayNode
                     && ((ArrayNode) x).size() == 2) {
-                int from = ((ArrayNode) x).get(0).asInt();
-                int to = ((ArrayNode) x).get(1).asInt();
+            	Integer to;
+                Integer from = ((ArrayNode) x).get(0).asInt();
+                if(!((ArrayNode) x).get(1).isNull())
+                  to = ((ArrayNode) x).get(1).asInt();
+                else
+                  to = null;
                 return new ArrayRangeProjection(path,
                         include,
                         projection,

--- a/query-api/src/test/java/com/redhat/lightblue/query/ProjectionParseTest.java
+++ b/query-api/src/test/java/com/redhat/lightblue/query/ProjectionParseTest.java
@@ -32,6 +32,8 @@ public class ProjectionParseTest {
     final String doc4p = "{\"field\":\"field.x\",\"include\":true,\"match\":{\"field\":\"field.x\",\"op\":\"$eq\",\"rvalue\":1},\"projection\":{\"field\":\"member\"}}";
     final String doc6 = "{\"field\":\"field.x\",\"include\":true, \"range\":[1,4],\"project\":{\"field\":\"member\"}}";
     final String doc6p = "{\"field\":\"field.x\",\"include\":true, \"range\":[1,4],\"projection\":{\"field\":\"member\"}}";
+    final String doc60 = "{\"field\":\"field.x\",\"include\":true, \"range\":[1,0],\"projection\":{\"field\":\"member\"}}";
+    final String doc6neg = "{\"field\":\"field.x\",\"include\":true, \"range\":[1,-8],\"projection\":{\"field\":\"member\"}}";
     final String doc7 = "[" + doc1 + "," + doc2 + "," + doc3 + "]";
     final String doc4s = "{\"field\":\"field.x\",\"include\":true,\"match\":{\"field\":\"field.x\",\"op\":\"$eq\",\"rvalue\":1},\"project\":{\"field\":\"member\"},\"sort\":{\"field\":\"$asc\"}}";
     final String doc6s = "{\"field\":\"field.x\",\"include\":true, \"range\":[1,4],\"project\":{\"field\":\"member\"},\"sort\":{\"field\":\"$asc\"}}";
@@ -144,8 +146,8 @@ public class ProjectionParseTest {
         Assert.assertEquals("member", ((FieldProjection) x.getProject()).getField().toString());
         Assert.assertTrue(((FieldProjection) x.getProject()).isInclude());
         Assert.assertTrue(!((FieldProjection) x.getProject()).isRecursive());
-        Assert.assertEquals(1, x.getFrom());
-        Assert.assertEquals(4, x.getTo());
+        Assert.assertEquals(1, x.getFrom().intValue());
+        Assert.assertEquals(4, x.getTo().intValue());
     }
     
     @Test
@@ -159,9 +161,28 @@ public class ProjectionParseTest {
         Assert.assertEquals("member", ((FieldProjection) x.getProject()).getField().toString());
         Assert.assertTrue(((FieldProjection) x.getProject()).isInclude());
         Assert.assertTrue(!((FieldProjection) x.getProject()).isRecursive());
-        Assert.assertEquals(1, x.getFrom());
-        Assert.assertEquals(4, x.getTo());
+        Assert.assertEquals(1, x.getFrom().intValue());
+        Assert.assertEquals(4, x.getTo().intValue());
     }
+    
+    @Test
+    public void doc6pTestZeroUpperBound() throws Exception {
+        Projection p = Projection.fromJson(JsonUtils.json(doc60));
+        Assert.assertTrue(p instanceof ArrayRangeProjection);
+        ArrayRangeProjection x = (ArrayRangeProjection) p;
+        Assert.assertEquals(1, x.getFrom().intValue());
+        Assert.assertEquals(0, x.getTo().intValue());
+    }
+    
+    @Test
+    public void doc6pTestNegativeUpperBound() throws Exception {
+        Projection p = Projection.fromJson(JsonUtils.json(doc6neg));
+        Assert.assertTrue(p instanceof ArrayRangeProjection);
+        ArrayRangeProjection x = (ArrayRangeProjection) p;
+        Assert.assertEquals(1, x.getFrom().intValue());
+        Assert.assertEquals(-8, x.getTo().intValue());
+    }
+
 
     @Test
     public void doc6sTest() throws Exception {
@@ -174,8 +195,8 @@ public class ProjectionParseTest {
         Assert.assertEquals("member", ((FieldProjection) x.getProject()).getField().toString());
         Assert.assertTrue(((FieldProjection) x.getProject()).isInclude());
         Assert.assertTrue(!((FieldProjection) x.getProject()).isRecursive());
-        Assert.assertEquals(1, x.getFrom());
-        Assert.assertEquals(4, x.getTo());
+        Assert.assertEquals(1, x.getFrom().intValue());
+        Assert.assertEquals(4, x.getTo().intValue());
         Assert.assertNotNull(x.getSort());
         Assert.assertEquals("field", ((SortKey) x.getSort()).getField().toString());
         Assert.assertTrue(!((SortKey) x.getSort()).isDesc());


### PR DESCRIPTION
Changed type of 'from' and 'to' in ArrayRangeProjector and ArrayRangeProjection to Integer from int to allow for null and 0 values for 'to'. 
Made changes to element inclusion/exclusion logic 
added tests to ProjectorTest for all 4 scenarios for range
