### PR TITLE
Elem match opt

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/assoc/ParentDocReference.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/ParentDocReference.java
@@ -31,12 +31,24 @@ import com.redhat.lightblue.util.Path;
 public class ParentDocReference extends DocReference {
 
     private final List<ResultDoc> parents=new ArrayList<>();
-
+    private final Path field;
+    private final ResolvedFieldBinding binding;
+    
     /**
      * Constructs a reference for the given document and field
      */
-    public ParentDocReference(ResultDoc document) {
+    public ParentDocReference(ResultDoc document,Path field,ResolvedFieldBinding binding) {
         super(document);
+        this.field=field;
+        this.binding=binding;
+    }
+    
+    public Path getField() {
+    	return field;
+    }
+    
+    public ResolvedFieldBinding getBinding() {
+    	return binding;
     }
 
     /**

--- a/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldBinding.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldBinding.java
@@ -363,10 +363,21 @@ public class ResolvedFieldBinding implements Serializable {
         }
     }
 
+    public List<ParentDocReference> getParentDocReferences(ResultDoc doc) {
+    	List<ParentDocReference> list=new ArrayList<>();
+    	KeyValueCursor<Path,JsonNode> nodeCursor=doc.getDoc().getAllNodes(valueField);
+    	while(nodeCursor.hasNext()) {
+    	    nodeCursor.next();
+    	    Path p=nodeCursor.getCurrentKey();
+    	    list.add(new ParentDocReference(doc,p,this));
+    	}
+    	return list;
+    }
+    
     public void refresh(ParentDocReference ref) {
         ResultDoc doc=ref.getDocument();
         if(doc.getMetadata()==entity) {
-            refresh(doc.getDoc().get(valueField));            
+            refresh(doc.getDoc().get(ref.getField()));            
         } else
             throw new RuntimeException("Unsupported binding");
     }

--- a/crud/src/main/java/com/redhat/lightblue/assoc/qrew/QueryRewriter.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/qrew/QueryRewriter.java
@@ -77,6 +77,7 @@ public final class QueryRewriter extends Rewriter {
         register(ExtendINsInOR.INSTANCE);
         register(ExtendNINsInAND.INSTANCE);
         register(PromoteNestedAND.INSTANCE);
+        register(SimpleElemMatchIsComparison.INSTANCE);
     }
 
     protected QueryExpression rewriteIteration(QueryExpression q) {

--- a/crud/src/main/java/com/redhat/lightblue/assoc/qrew/rules/SimpleElemMatchIsComparison.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/qrew/rules/SimpleElemMatchIsComparison.java
@@ -1,0 +1,68 @@
+/*
+ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.assoc.qrew.rules;
+
+import com.redhat.lightblue.query.*;
+
+import com.redhat.lightblue.assoc.qrew.Rewriter;
+
+import com.redhat.lightblue.util.Path;
+
+/**
+ * If 
+ * <pre>
+ *   q={array: X, elemMatch: { x op value } or { x op y } }
+ * </pre>
+ * this rewrites q as
+ * <pre>
+ *   q={ field: X.*.x op value | y }
+ * </pre>
+ */
+public class SimpleElemMatchIsComparison extends Rewriter {
+
+    public static final SimpleElemMatchIsComparison INSTANCE=new SimpleElemMatchIsComparison();
+    
+    @Override
+    public QueryExpression rewrite(QueryExpression q) {
+        ArrayMatchExpression ae=dyncast(ArrayMatchExpression.class, q);
+        QueryExpression newq=q;
+        if(ae!=null) {
+            QueryExpression nestedq=ae.getElemMatch();
+            ValueComparisonExpression vce;
+            FieldComparisonExpression fce;
+            NaryValueRelationalExpression nvre;
+            NaryFieldRelationalExpression nfre;
+            if( (vce=dyncast(ValueComparisonExpression.class,nestedq))!=null) {
+                newq=new ValueComparisonExpression(normalize(ae,vce.getField()),vce.getOp(),vce.getRvalue());
+            } else if( (fce=dyncast(FieldComparisonExpression.class,nestedq))!=null) {
+                newq=new FieldComparisonExpression(normalize(ae,fce.getField()),fce.getOp(),normalize(ae,fce.getRfield()));
+            } else if( (nvre=dyncast(NaryValueRelationalExpression.class,nestedq))!=null) {
+                newq=new NaryValueRelationalExpression(normalize(ae,nvre.getField()),nvre.getOp(),nvre.getValues());
+            } else if( (nfre=dyncast(NaryFieldRelationalExpression.class,nestedq))!=null) {
+                newq=new NaryFieldRelationalExpression(normalize(ae,nfre.getField()),nfre.getOp(),nfre.getRfield());
+            }
+        }
+        return newq;
+    }
+
+    private Path normalize(ArrayMatchExpression ae,Path field) {
+        Path p=new Path(new Path(ae.getArray(),Path.ANYPATH),field);
+        return p.normalize();
+    }
+}

--- a/crud/src/main/java/com/redhat/lightblue/mediator/QueryPlanNodeExecutor.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/QueryPlanNodeExecutor.java
@@ -201,8 +201,10 @@ public class QueryPlanNodeExecutor {
                     // that are children of the documents of this node
                     list=new ArrayList<>(source.docs.size());
                     for(ResultDoc sourceDoc:source.docs) {
-                        list.add((DocReference)new ParentDocReference(sourceDoc));
-                    }
+                    	for(ResolvedFieldBinding binding:sourceBindings) {
+                    		list.addAll(binding.getParentDocReferences(sourceDoc));
+                    	}
+                    }                        
                 }
                 LOGGER.debug("Adding {} docs from node {} to node {}, source has {} docs",
                              list.size(),
@@ -227,7 +229,8 @@ public class QueryPlanNodeExecutor {
                             binding.refresh((ChildDocReference)docReference);
                     } else {
                         for(ResolvedFieldBinding binding:sourceBindings)
-                            binding.refresh((ParentDocReference)docReference);
+                        	if(binding == ((ParentDocReference)docReference).getBinding())
+                        		binding.refresh((ParentDocReference)docReference);
                     }
                 }
                 

--- a/crud/src/test/resources/composite/L.json
+++ b/crud/src/test/resources/composite/L.json
@@ -42,6 +42,19 @@
             },
             "name": {
                 "type": "string"
+            },
+            "us": {
+                "type":"reference",
+                "entity":"U",
+                "versionValue":"0.0.1",
+                "query":{
+                    "array":"legalEntities",
+                    "elemMatch": {
+                        "field":"legalEntityId",
+                        "op":"=",
+                        "rfield":"$parent.$parent.$parent._id"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Work around a case where A -> B, B is retrieved first, and A and B are related through an elemMatch query by rewriting elemMatch as a simple query. This won't work for more involved queries.