### PR TITLE
fixes #479 - rename AbstractCRUDTestControllerTest to LightblueTestHa…

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/test/LightblueTestHarness.java
+++ b/test/src/main/java/com/redhat/lightblue/test/LightblueTestHarness.java
@@ -61,7 +61,7 @@ import com.redhat.lightblue.metadata.Metadata;
  *
  * @author dcrissman
  */
-public abstract class AbstractCRUDTestController {
+public abstract class LightblueTestHarness {
 
     public static final String REMOVE_ALL_HOOKS = "ALL";
 
@@ -82,7 +82,7 @@ public abstract class AbstractCRUDTestController {
     /**
      * Defaults to statically loading lightblue.
      */
-    public AbstractCRUDTestController() throws Exception {
+    public LightblueTestHarness() throws Exception {
         this(true);
     }
 
@@ -99,7 +99,7 @@ public abstract class AbstractCRUDTestController {
      * @throws InvocationTargetException
      * @throws InstantiationException
      */
-    public AbstractCRUDTestController(boolean loadStatically) throws Exception {
+    public LightblueTestHarness(boolean loadStatically) throws Exception {
         if (!loadStatically || lightblueFactory == null) {
             lightblueFactory = new LightblueFactory(
                     new DataSourcesConfiguration(getDatasourcesJson()),

--- a/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
+++ b/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
@@ -17,9 +17,9 @@ public class AbstractCRUDTestControllerTest {
     @Test
     public void testStripHooks_All() throws Exception {
         JsonNode node = loadJsonNode("./metadata/hooks.json");
-        AbstractCRUDTestController.stripHooks(node,
+        LightblueTestHarness.stripHooks(node,
                 new HashSet<String>(Arrays.asList(
-                        AbstractCRUDTestController.REMOVE_ALL_HOOKS)));
+                        LightblueTestHarness.REMOVE_ALL_HOOKS)));
 
         assertNull(node.get("entityInfo").get("hooks"));
     }
@@ -27,7 +27,7 @@ public class AbstractCRUDTestControllerTest {
     @Test
     public void testStripHooks_Selective() throws Exception {
         JsonNode node = loadJsonNode("./metadata/hooks.json");
-        AbstractCRUDTestController.stripHooks(node,
+        LightblueTestHarness.stripHooks(node,
                 new HashSet<String>(Arrays.asList("someHook")));
 
         JsonNode hooksNode = node.get("entityInfo").get("hooks");
@@ -38,7 +38,7 @@ public class AbstractCRUDTestControllerTest {
     @Test
     public void testEnsureDatasource() throws Exception {
         JsonNode node = loadJsonNode("./metadata/datasource.json");
-        AbstractCRUDTestController.ensureDatasource(node, "anotherdatasource");
+        LightblueTestHarness.ensureDatasource(node, "anotherdatasource");
 
         assertEquals("anotherdatasource", node.get("entityInfo").get(
                 "datastore").get("datasource").asText());
@@ -47,7 +47,7 @@ public class AbstractCRUDTestControllerTest {
     @Test
     public void testGrantAnyoneAccess() throws Exception {
         JsonNode node = loadJsonNode("./metadata/access.json");
-        AbstractCRUDTestController.grantAnyoneAccess(node);
+        LightblueTestHarness.grantAnyoneAccess(node);
 
         assertEquals("anyone",
                 node.get("schema").get("access").get("insert").get(0).textValue());


### PR DESCRIPTION
…rness

While this is a breaking change, only lightblue-mongo uses this class directly. A follow up PR will be submitted over there as well.