### PR TITLE
Standardize on currentThread class loader

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/AbstractMetadataConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/AbstractMetadataConfiguration.java
@@ -92,7 +92,7 @@ public abstract class AbstractMetadataConfiguration implements MetadataConfigura
                     // instantiate the class
                     Object o = null;
                     try {
-                        o = Class.forName(clazz).newInstance();
+                        o = Thread.currentThread().getContextClassLoader().loadClass(clazz).newInstance();
                     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException ex) {
                         throw Error.get(MetadataConstants.ERR_CONFIG_NOT_VALID, ex.getMessage());
                     }
@@ -120,7 +120,7 @@ public abstract class AbstractMetadataConfiguration implements MetadataConfigura
                     }
 
                     try {
-                        DataStoreParser instance = (DataStoreParser) Class.forName(clazz).newInstance();
+                        DataStoreParser instance = (DataStoreParser) Thread.currentThread().getContextClassLoader().loadClass(clazz).newInstance();
                         AbstractMap.SimpleEntry<String, DataStoreParser> stringDataStoreParserSimpleEntry = new AbstractMap.SimpleEntry<>(name, instance);
                         backendParsers.add(stringDataStoreParserSimpleEntry);
                     } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
@@ -140,7 +140,7 @@ public abstract class AbstractMetadataConfiguration implements MetadataConfigura
                     }
 
                     try {
-                        PropertyParser instance = (PropertyParser) Class.forName(clazz).newInstance();
+                        PropertyParser instance = (PropertyParser) Thread.currentThread().getContextClassLoader().loadClass(clazz).newInstance();
 
                         AbstractMap.SimpleEntry<String, PropertyParser> stringPropertyParserSimpleEntry = new AbstractMap.SimpleEntry<>(name, instance);
                         propertyParsers.add(stringPropertyParserSimpleEntry);

--- a/config/src/main/java/com/redhat/lightblue/config/ControllerConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/ControllerConfiguration.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import com.redhat.lightblue.util.JsonInitializable;
 
 /**
@@ -38,7 +37,7 @@ public class ControllerConfiguration implements JsonInitializable, Serializable 
     private static final long serialVersionUID = 1l;
 
     private static final Logger LOGGER=LoggerFactory.getLogger(ControllerConfiguration.class);
-    
+
     private String backend;
     private Class<? extends ControllerFactory> controllerFactory;
     private ObjectNode extensions;
@@ -77,7 +76,7 @@ public class ControllerConfiguration implements JsonInitializable, Serializable 
      * @param clazz the class to set
      */
     public void setControllerFactory(Class<? extends ControllerFactory> clazz) {
-        this.controllerFactory = clazz;
+        controllerFactory = clazz;
     }
 
     /**
@@ -94,6 +93,7 @@ public class ControllerConfiguration implements JsonInitializable, Serializable 
         extensions=node;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void initializeFromJson(JsonNode node) {
         try {
@@ -104,7 +104,8 @@ public class ControllerConfiguration implements JsonInitializable, Serializable 
                 }
                 x = node.get("controllerFactory");
                 if (x != null) {
-                    controllerFactory = (Class<ControllerFactory>) Class.forName(x.asText());
+                    controllerFactory = (Class<ControllerFactory>) Thread.currentThread().getContextClassLoader().loadClass(
+                            x.asText());
                 }
                 extensions=(ObjectNode)node.get("extensions");
                 LOGGER.debug("Initialized: source={} backend={} controllerFactory={} extensions={}",node,backend,controllerFactory,extensions);

--- a/config/src/main/java/com/redhat/lightblue/config/DataSourcesConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/DataSourcesConfiguration.java
@@ -125,7 +125,7 @@ public class DataSourcesConfiguration implements JsonInitializable, Serializable
                 String type = typeNode.asText();
                 LOGGER.debug("{} is a {}", name, type);
                 try {
-                    Class clazz = Class.forName(type);
+                    Class clazz = Thread.currentThread().getContextClassLoader().loadClass(type);
                     DataSourceConfiguration ds = (DataSourceConfiguration) clazz.newInstance();
                     ds.initializeFromJson(dsNode);
                     datasources.put(name, ds);

--- a/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
+++ b/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
@@ -23,9 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -92,30 +89,12 @@ public final class LightblueFactory implements Serializable {
     }
 
     public LightblueFactory(DataSourcesConfiguration datasources, JsonNode crudNode, JsonNode metadataNode) {
-        this(datasources, crudNode, metadataNode, null);
-    }
-
-    public LightblueFactory(DataSourcesConfiguration datasources, JsonNode crudNode, JsonNode metadataNode, URL[] pluginURLs) {
         if (datasources == null) {
             throw new IllegalArgumentException("datasources cannot be null");
         }
         this.datasources = datasources;
         this.crudNode = crudNode;
         this.metadataNode = metadataNode;
-
-        if (pluginURLs != null) {
-            ClassLoader currentThreadLoader = Thread.currentThread().getContextClassLoader();
-            boolean skip = false;
-            if(currentThreadLoader instanceof URLClassLoader){
-                //protect against effectively adding the same URLClassLoader multiple times.
-                skip = Arrays.asList(((URLClassLoader) currentThreadLoader).getURLs())
-                        .containsAll(Arrays.asList(pluginURLs));
-            }
-            if(!skip){
-                Thread.currentThread().setContextClassLoader(
-                        new URLClassLoader(pluginURLs, currentThreadLoader));
-            }
-        }
     }
 
     private synchronized void initializeParser()


### PR DESCRIPTION
Use currentThread's classLoader instead of Class.forName. This is part of https://github.com/lightblue-platform/lightblue-rest/issues/162