### PR TITLE
Honor LightblueFactoryAware hook config parsers

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/SimpleHookResolver.java
+++ b/config/src/main/java/com/redhat/lightblue/config/SimpleHookResolver.java
@@ -20,6 +20,7 @@ public class SimpleHookResolver implements HookResolver {
     public SimpleHookResolver(List<HookConfigurationParser> hookConfigurationParsers, LightblueFactory lightblueFactory) {
         if (hookConfigurationParsers != null && !hookConfigurationParsers.isEmpty()) {
             for (HookConfigurationParser parser : hookConfigurationParsers) {
+                lightblueFactory.injectDependencies(parser);
                 CRUDHook hook = parser.getCRUDHook();
                 lightblueFactory.injectDependencies(hook);
                 map.put(parser.getName(), hook);


### PR DESCRIPTION
The motivation for this is because hooks are created by parsers, and it is more natural to inject what the hook needs in its constructor (constructor injection), which simplifies testing. This requries the parser to have hook dependencies, which is why it'd be nice if parsers could get `LightblueFactory` injected.