### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/assoc/QueryPlanData.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/QueryPlanData.java
@@ -58,7 +58,7 @@ public class QueryPlanData implements Serializable {
      */
     public void copyFrom(QueryPlanData source) {
         if(source.conjuncts!=null)
-            conjuncts=new ArrayList<Conjunct>(source.conjuncts);
+            conjuncts=new ArrayList<>(source.conjuncts);
         else
             conjuncts=null;
     }

--- a/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldBinding.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldBinding.java
@@ -405,7 +405,7 @@ public class ResolvedFieldBinding implements Serializable {
             if(valueNode==null) 
                 ((ListBinding)binding).getList().setList(new ArrayList());
             else {
-                List<Value> l=new ArrayList<Value>( ((ArrayNode)valueNode).size());
+                List<Value> l=new ArrayList<>(((ArrayNode) valueNode).size());
                 for(Iterator<JsonNode> itr=((ArrayNode)valueNode).elements();itr.hasNext();) {
                     l.add(new Value(type.fromJson(itr.next())));
                 }

--- a/crud/src/main/java/com/redhat/lightblue/assoc/SortAndLimit.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/SortAndLimit.java
@@ -82,7 +82,7 @@ public class SortAndLimit {
         int size=resultList.size();
         int f=from==null?0:from.intValue();
         if(f>=size)
-            return new ArrayList<ResultDoc>();
+            return new ArrayList<>();
         
         int t=to==null?size-1:to.intValue();
         if(t>=size)

--- a/crud/src/main/java/com/redhat/lightblue/crud/AbstractBulkJsonObject.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/AbstractBulkJsonObject.java
@@ -49,7 +49,7 @@ import com.redhat.lightblue.Request;
  */
 abstract class AbstractBulkJsonObject<T extends JsonObject> extends JsonObject {
 
-    protected final List<T> entries=new ArrayList<T>();
+    protected final List<T> entries=new ArrayList<>();
 
     /**
      * Returns all entries in the bulk object

--- a/crud/src/main/java/com/redhat/lightblue/crud/validator/RequiredChecker.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/validator/RequiredChecker.java
@@ -67,7 +67,7 @@ public class RequiredChecker implements FieldConstraintDocChecker {
                                               JsonDoc doc) {
         LOGGER.debug("Checking {}",fieldMetadataPath);
         int nAnys = fieldMetadataPath.nAnys();
-        List<Path> errors = new ArrayList<Path>();
+        List<Path> errors = new ArrayList<>();
         if (nAnys == 0) {
             JsonNode fieldNode=doc.get(fieldMetadataPath);
             if (fieldNode == null) {

--- a/crud/src/test/java/com/redhat/lightblue/crud/ConstraintValidatorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/crud/ConstraintValidatorTest.java
@@ -77,7 +77,7 @@ public class ConstraintValidatorTest extends AbstractJsonSchemaTest {
             Map<String, ? extends EntityConstraintChecker> entityConstraintCheckers) {
 
         Registry<String, FieldConstraintChecker> fieldCheckerRegistry =
-                new DefaultRegistry<String, FieldConstraintChecker>();
+                new DefaultRegistry<>();
         fieldCheckerRegistry.add(new DefaultFieldConstraintValidators());
         if (fieldConstraintCheckers != null) {
             for (Entry<String, ? extends FieldConstraintChecker> checker : fieldConstraintCheckers.entrySet()) {
@@ -86,7 +86,7 @@ public class ConstraintValidatorTest extends AbstractJsonSchemaTest {
         }
 
         Registry<String, EntityConstraintChecker> entityCheckerRegistry =
-                new DefaultRegistry<String, EntityConstraintChecker>();
+                new DefaultRegistry<>();
         entityCheckerRegistry.add(new EmptyEntityConstraintValidators());
         if (entityConstraintCheckers != null) {
             for (Entry<String, ? extends EntityConstraintChecker> checker : entityConstraintCheckers.entrySet()) {
@@ -102,9 +102,9 @@ public class ConstraintValidatorTest extends AbstractJsonSchemaTest {
             List<? extends EntityConstraint> entityConstraints,
             Map<String,FieldConstraintParser<JsonNode>> fieldConstraintParsers) {
 
-        TestDataStoreParser<JsonNode> dsParser = new TestDataStoreParser<JsonNode>();
+        TestDataStoreParser<JsonNode> dsParser = new TestDataStoreParser<>();
 
-        Extensions<JsonNode> extensions = new Extensions<JsonNode>();
+        Extensions<JsonNode> extensions = new Extensions<>();
         extensions.registerDataStoreParser(dsParser.getDefaultName(), dsParser);
         extensions.addDefaultExtensions();
         if (fieldConstraintParsers != null) {
@@ -120,7 +120,7 @@ public class ConstraintValidatorTest extends AbstractJsonSchemaTest {
 
         EntityMetadata entityMetadata = jsonParser.parseEntityMetadata(node);
         if ((entityConstraints != null) && !entityConstraints.isEmpty()) {
-            entityMetadata.setConstraints(new ArrayList<EntityConstraint>(entityConstraints));
+            entityMetadata.setConstraints(new ArrayList<>(entityConstraints));
         }
 
         return entityMetadata;
@@ -196,7 +196,7 @@ public class ConstraintValidatorTest extends AbstractJsonSchemaTest {
 
         JsonNode validatorNode = loadJsonNode("crud/validator/schema-test-validation-testFieldConstraint.json");
 
-        Map<String, FieldConstraintParser<JsonNode>> fieldConstraintParsers = new HashMap<String, FieldConstraintParser<JsonNode>>();
+        Map<String, FieldConstraintParser<JsonNode>> fieldConstraintParsers = new HashMap<>();
         fieldConstraintParsers.put("testFieldConstraint", new TestFieldConstraintParser(new TestFieldConstraint("testFieldConstraintChecker")));
 
         EntityMetadata entityMetadata = createEntityMetadata(validatorNode, null, fieldConstraintParsers);
@@ -217,12 +217,12 @@ public class ConstraintValidatorTest extends AbstractJsonSchemaTest {
 
         JsonNode validatorNode = loadJsonNode("crud/validator/schema-test-validation-testFieldConstraint.json");
 
-        Map<String, FieldConstraintParser<JsonNode>> fieldConstraintParsers = new HashMap<String, FieldConstraintParser<JsonNode>>();
+        Map<String, FieldConstraintParser<JsonNode>> fieldConstraintParsers = new HashMap<>();
         fieldConstraintParsers.put("testFieldConstraint", new TestFieldConstraintParser(new TestFieldConstraint(fieldConstraintCheckerName)));
 
         EntityMetadata entityMetadata = createEntityMetadata(validatorNode, null, fieldConstraintParsers);
 
-        Map<String, FieldConstraintChecker> fieldConstraintCheckers = new HashMap<String, FieldConstraintChecker>();
+        Map<String, FieldConstraintChecker> fieldConstraintCheckers = new HashMap<>();
         fieldConstraintCheckers.put(fieldConstraintCheckerName, new FieldConstraintChecker() {
         });
 

--- a/crud/src/test/java/com/redhat/lightblue/crud/validator/EnumCheckerTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/crud/validator/EnumCheckerTest.java
@@ -64,7 +64,7 @@ public class EnumCheckerTest {
         final String name = "Fake Name";
 
         Enum e = new Enum(name);
-        e.setValues(new HashSet<EnumValue>(Arrays.asList(new EnumValue(name, null))));
+        e.setValues(new HashSet<>(Arrays.asList(new EnumValue(name, null))));
 
         ConstraintValidator validator = mock(ConstraintValidator.class);
         mockEnum(validator, e);

--- a/crud/src/test/java/com/redhat/lightblue/mediator/CompositeFinderTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/CompositeFinderTest.java
@@ -169,7 +169,7 @@ public class CompositeFinderTest extends AbstractJsonSchemaTest {
         factory.addCRUDController("mongo", new CompositeTestCrudController(new TestCrudController.GetData() {
                 public List<JsonDoc> getData(String entityName) {
                     try {
-                        List<JsonDoc> docs=new ArrayList<JsonDoc>();
+                        List<JsonDoc> docs=new ArrayList<>();
                         JsonNode node=loadJsonNode("composite/"+entityName+"_data.json");
                         if(node instanceof ArrayNode) {
                             for(Iterator<JsonNode> itr=((ArrayNode)node).elements();itr.hasNext();)

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/ArrayElement.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/ArrayElement.java
@@ -32,7 +32,7 @@ public abstract class ArrayElement implements FieldTreeNode, Serializable {
     private Type type;
 
     private FieldTreeNode parent = null;
-    private final Map<String, Object> properties = new HashMap<String, Object>();
+    private final Map<String, Object> properties = new HashMap<>();
 
     public ArrayElement() {
     }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/EntitySchema.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/EntitySchema.java
@@ -296,7 +296,7 @@ public class EntitySchema implements Serializable {
                             Path idName=fieldName.suffix(-(lastAny+1));
                             List<Path> ids=idMap.get(arrayName);
                             if(ids==null) {
-                                idMap.put(arrayName,ids=new ArrayList<Path>());
+                                idMap.put(arrayName,ids=new ArrayList<>());
                             }
                             ids.add(idName);
                         }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/Enum.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/Enum.java
@@ -55,7 +55,7 @@ public class Enum implements Serializable {
     }
 
     public void setValues(Collection<String> values){
-        Set<EnumValue> evSet = new HashSet<EnumValue>();
+        Set<EnumValue> evSet = new HashSet<>();
         for(String string : values){
             evSet.add(new EnumValue(string, null));
         }
@@ -66,14 +66,14 @@ public class Enum implements Serializable {
      * The {@link EnumValue}s allowed in this enumeration.
      */
     public Set<EnumValue> getEnumValues() {
-        return new HashSet<EnumValue>(values);
+        return new HashSet<>(values);
     }
 
     /**
      * The values allowed in this enumeration.
      */
     public Set<String> getValues(){
-        Set<String> strings = new HashSet<String>();
+        Set<String> strings = new HashSet<>();
         for(EnumValue v : values){
             strings.add(v.getName());
         }

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/parser/JSONMetadataParser.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/parser/JSONMetadataParser.java
@@ -275,7 +275,7 @@ public class JSONMetadataParser extends MetadataParser<JsonNode> {
 
     @Override
     public Set<String> findFieldsNotIn(JsonNode elements, Set<String> removeAllFields) {
-        final HashSet<String> strings = new HashSet<String>();
+        final HashSet<String> strings = new HashSet<>();
         final Iterator<String> stringIterator = elements.fieldNames();
         while (stringIterator.hasNext()) {
             String next = stringIterator.next();

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/UIDTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/UIDTest.java
@@ -153,7 +153,7 @@ public class UIDTest extends AbstractJsonNodeTest {
     @Test
     public void userTest() throws Exception {
         JsonNode node = loadJsonNode("usermd.json");
-        Extensions<JsonNode> extensions = new Extensions<JsonNode>();
+        Extensions<JsonNode> extensions = new Extensions<>();
         extensions.addDefaultExtensions();
         extensions.registerDataStoreParser("mongo", new DataStoreParser<JsonNode>() {
             @Override

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/parser/JSONMetadataParserTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/parser/JSONMetadataParserTest.java
@@ -507,7 +507,7 @@ public class JSONMetadataParserTest extends AbstractJsonSchemaTest {
         String enumValue2 = "FakeEnumValue2";
 
         Enum e = new Enum(enumName);
-        e.setValues(new HashSet<EnumValue>(Arrays.asList(
+        e.setValues(new HashSet<>(Arrays.asList(
                 new EnumValue(enumValue1, null),
                 new EnumValue(enumValue2, null))));
 
@@ -535,7 +535,7 @@ public class JSONMetadataParserTest extends AbstractJsonSchemaTest {
         String enumDescription2 = "this is a fake description of enum value 2";
 
         Enum e = new Enum(enumName);
-        e.setValues(new HashSet<EnumValue>(Arrays.asList(
+        e.setValues(new HashSet<>(Arrays.asList(
                 new EnumValue(enumValue1, enumDescription1),
                 new EnumValue(enumValue2, enumDescription2))));
 

--- a/query-api/src/main/java/com/redhat/lightblue/query/BindFields.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/BindFields.java
@@ -145,6 +145,6 @@ public class BindFields<T extends FieldBinding> extends QueryIterator {
                                                                 Path ctx,
                                                                 List<T> bindingResult,
                                                                 Set<Path> bindRequest) {
-        return new BindFields<T>(bindingResult, bindRequest).iterate(q, ctx);
+        return new BindFields<>(bindingResult, bindRequest).iterate(q, ctx);
     }
 }

--- a/query-api/src/main/java/com/redhat/lightblue/query/GetQueryFields.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/GetQueryFields.java
@@ -97,7 +97,7 @@ public class GetQueryFields<T extends FieldInfo> extends QueryIterator {
      * Returns field information about the query
      */
     public static List<FieldInfo> getQueryFields(QueryExpression q) {
-        List<FieldInfo> list = new ArrayList<FieldInfo>(16);
+        List<FieldInfo> list = new ArrayList<>(16);
         getQueryFields(list,q);
         return list;
     }
@@ -115,7 +115,7 @@ public class GetQueryFields<T extends FieldInfo> extends QueryIterator {
      * The implementation should populate the list with the field information
      */
     public static <T extends FieldInfo> void getQueryFields(List<T> fields, QueryExpression q,Path ctx) {
-        new GetQueryFields<T>(fields).iterate(q, ctx);
+        new GetQueryFields<>(fields).iterate(q, ctx);
     }
 
 }

--- a/query-api/src/main/java/com/redhat/lightblue/query/QueryIterator.java
+++ b/query-api/src/main/java/com/redhat/lightblue/query/QueryIterator.java
@@ -119,7 +119,7 @@ public abstract class QueryIterator extends QueryIteratorSkeleton<QueryExpressio
      * expressions and returns that.
      */
     protected QueryExpression itrNaryLogicalExpression(NaryLogicalExpression q, Path context) {
-        CopyOnWriteIterator<QueryExpression> itr = new CopyOnWriteIterator<QueryExpression>(q.getQueries());
+        CopyOnWriteIterator<QueryExpression> itr = new CopyOnWriteIterator<>(q.getQueries());
         while (itr.hasNext()) {
             QueryExpression nestedq = itr.next();
             QueryExpression newq = iterate(nestedq, context);

--- a/test/src/main/java/com/redhat/lightblue/test/Assert.java
+++ b/test/src/main/java/com/redhat/lightblue/test/Assert.java
@@ -51,7 +51,7 @@ public final class Assert {
      * @throws MultipleFailureException
      */
     public static void assertNoDataErrors(Response response) throws MultipleFailureException{
-        List<Throwable> errors = new ArrayList<Throwable>();
+        List<Throwable> errors = new ArrayList<>();
         for(DataError error : response.getDataErrors()){
             errors.add(new Exception("DataError: " + error.toJson().toString()));
         }

--- a/test/src/main/java/com/redhat/lightblue/test/FakeClientIdentification.java
+++ b/test/src/main/java/com/redhat/lightblue/test/FakeClientIdentification.java
@@ -32,7 +32,7 @@ public class FakeClientIdentification extends ClientIdentification {
     private final Set<String> validUserRoles;
 
     public FakeClientIdentification(String principal, String... validUserRoles){
-        this(principal, new HashSet<String>(Arrays.asList(validUserRoles)));
+        this(principal, new HashSet<>(Arrays.asList(validUserRoles)));
     }
 
     public FakeClientIdentification(String principal, Set<String> validUserRoles){

--- a/test/src/main/java/com/redhat/lightblue/test/LightblueTestHarness.java
+++ b/test/src/main/java/com/redhat/lightblue/test/LightblueTestHarness.java
@@ -255,7 +255,7 @@ public abstract class LightblueTestHarness {
      * {@link #REMOVE_ALL_HOOKS}, which will remove all hooks.
      */
     public Set<String> getHooksToRemove() {
-        return new HashSet<String>(Arrays.asList(REMOVE_ALL_HOOKS));
+        return new HashSet<>(Arrays.asList(REMOVE_ALL_HOOKS));
     }
 
     /**

--- a/test/src/main/java/com/redhat/lightblue/test/MetadataUtil.java
+++ b/test/src/main/java/com/redhat/lightblue/test/MetadataUtil.java
@@ -45,9 +45,9 @@ public final class MetadataUtil {
     public static JSONMetadataParser createJSONMetadataParser(
             String backend,
             Map<String, ? extends FieldConstraintParser<JsonNode>> fieldConstraintParsers){
-        FakeDataStoreParser<JsonNode> dsParser = new FakeDataStoreParser<JsonNode>(backend);
+        FakeDataStoreParser<JsonNode> dsParser = new FakeDataStoreParser<>(backend);
 
-        Extensions<JsonNode> extensions = new Extensions<JsonNode>();
+        Extensions<JsonNode> extensions = new Extensions<>();
         extensions.registerDataStoreParser(dsParser.getDefaultName(), dsParser);
         extensions.addDefaultExtensions();
         if (fieldConstraintParsers != null) {
@@ -82,7 +82,7 @@ public final class MetadataUtil {
 
         EntityMetadata entityMetadata = jsonParser.parseEntityMetadata(node);
         if ((entityConstraints != null) && !entityConstraints.isEmpty()) {
-            entityMetadata.setConstraints(new ArrayList<EntityConstraint>(entityConstraints));
+            entityMetadata.setConstraints(new ArrayList<>(entityConstraints));
         }
 
         return entityMetadata;

--- a/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
+++ b/test/src/test/java/com/redhat/lightblue/test/AbstractCRUDTestControllerTest.java
@@ -18,7 +18,7 @@ public class AbstractCRUDTestControllerTest {
     public void testStripHooks_All() throws Exception {
         JsonNode node = loadJsonNode("./metadata/hooks.json");
         LightblueTestHarness.stripHooks(node,
-                new HashSet<String>(Arrays.asList(
+                new HashSet<>(Arrays.asList(
                         LightblueTestHarness.REMOVE_ALL_HOOKS)));
 
         assertNull(node.get("entityInfo").get("hooks"));
@@ -28,7 +28,7 @@ public class AbstractCRUDTestControllerTest {
     public void testStripHooks_Selective() throws Exception {
         JsonNode node = loadJsonNode("./metadata/hooks.json");
         LightblueTestHarness.stripHooks(node,
-                new HashSet<String>(Arrays.asList("someHook")));
+                new HashSet<>(Arrays.asList("someHook")));
 
         JsonNode hooksNode = node.get("entityInfo").get("hooks");
         assertNotNull(hooksNode);

--- a/util/src/main/java/com/redhat/lightblue/util/AbstractTreeCursor.java
+++ b/util/src/main/java/com/redhat/lightblue/util/AbstractTreeCursor.java
@@ -277,7 +277,7 @@ public abstract class AbstractTreeCursor<N> {
     protected abstract boolean hasChildren(N node);
 
     private void push() {
-        stack.addLast(new LevelState<N>(currentNode, currentCursor));
+        stack.addLast(new LevelState<>(currentNode, currentCursor));
     }
 
     private void pop() {

--- a/util/src/main/java/com/redhat/lightblue/util/CopyOnWriteIterator.java
+++ b/util/src/main/java/com/redhat/lightblue/util/CopyOnWriteIterator.java
@@ -92,7 +92,7 @@ public class CopyOnWriteIterator<T> implements Iterator<T> {
 
     private void copy() {
         if (copiedList == null) {
-            copiedList = new ArrayList<T>(list);
+            copiedList = new ArrayList<>(list);
         }
     }
 }

--- a/util/src/main/java/com/redhat/lightblue/util/DocComparator.java
+++ b/util/src/main/java/com/redhat/lightblue/util/DocComparator.java
@@ -149,7 +149,7 @@ public abstract class DocComparator<BaseType,ValueType,ObjectType,ArrayType> {
          * Constructs a Difference denoting no difference
          */
         public Difference(int numFields) {
-            delta=new ArrayList<Delta<T>>();
+            delta=new ArrayList<>();
             numUnchangedFields=numFields;
         }
 
@@ -458,10 +458,10 @@ public abstract class DocComparator<BaseType,ValueType,ObjectType,ArrayType> {
             return compareObjects(field1,asObject(node1),field2,asObject(node2));
         } else {
             if(!(isNull(node1) && isNull(node2)) ) {
-                return new Difference<BaseType>(new Modification(field1,node1,field2,node2));
+                return new Difference<>(new Modification(field1, node1, field2, node2));
             }
         }
-        return new Difference<BaseType>(1);
+        return new Difference<>(1);
     }
     
     /**

--- a/util/src/main/java/com/redhat/lightblue/util/Tuples.java
+++ b/util/src/main/java/com/redhat/lightblue/util/Tuples.java
@@ -90,8 +90,8 @@ public class Tuples<T> {
 
         public TupleItr(List<Iterable<X>> list) {
             coll = new ArrayList<>(list);
-            tuple = new ArrayList<X>(Collections.nCopies(coll.size(), (X) null));
-            itrList = new ArrayList<Iterator<X>>(Collections.nCopies(coll.size(), (Iterator<X>) null));
+            tuple = new ArrayList<>(Collections.nCopies(coll.size(), (X) null));
+            itrList = new ArrayList<>(Collections.nCopies(coll.size(), (Iterator<X>) null));
         }
 
         @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “   The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.