### PR TITLE
"equals(Object obj)" should test argument type

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/crud/valuegenerators/GeneratorKey.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/valuegenerators/GeneratorKey.java
@@ -34,7 +34,7 @@ class GeneratorKey {
     }
 
     public boolean equals(Object x) {
-        if(x!=null)
+        if(x!=null && x.getClass() == this.getClass())
             try {
                 return ((GeneratorKey)x).type==type&&
                     (  (backend==null&& ((GeneratorKey)x).backend==null) ||

--- a/crud/src/main/java/com/redhat/lightblue/eval/SortableItem.java
+++ b/crud/src/main/java/com/redhat/lightblue/eval/SortableItem.java
@@ -77,6 +77,8 @@ public class SortableItem implements Comparable<SortableItem> {
     
     @Override
     public boolean equals(Object x) {
+        if(x == null || x.getClass() != this.getClass())
+            return false;
         try {
             return compareTo((SortableItem)x)==0;
         } catch (Exception e) {

--- a/util/src/main/java/com/redhat/lightblue/util/DocComparator.java
+++ b/util/src/main/java/com/redhat/lightblue/util/DocComparator.java
@@ -377,6 +377,8 @@ public abstract class DocComparator<BaseType,ValueType,ObjectType,ArrayType> {
 
         @Override
         public boolean equals(Object x) {
+            if(x == null || x.getClass() != this.getClass())
+                return false;
             try {
                 DefaultIdentity d=(DefaultIdentity)x;
                 for(int i=0;i<nodes.length;i++) {
@@ -592,6 +594,8 @@ public abstract class DocComparator<BaseType,ValueType,ObjectType,ArrayType> {
         }
 
         public boolean equals(Object o) {
+            if(o == null || o.getClass() != this.getClass())
+                return false;
             try {
                 return ((Pair)o).i1==i1&&
                     ((Pair)o).i2==i2;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - “  "equals(Object obj)" should test argument type ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2097
Please let me know if you have any questions.
Ayman Abdelghany.