### PR TITLE
Method invokes inefficient Number constructor; use static valueOf instead

### DIFF
--- a/metadata/src/main/java/com/redhat/lightblue/metadata/types/BigDecimalType.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/types/BigDecimalType.java
@@ -78,9 +78,9 @@ public final class BigDecimalType implements Type, Serializable {
             } else if (obj instanceof Number) {
                 if (obj instanceof Double
                         || obj instanceof Float) {
-                    value = new BigDecimal(((Number) obj).doubleValue());
+                    value = BigDecimal.valueOf(((Number) obj).doubleValue());
                 } else {
-                    value = new BigDecimal(((Number) obj).longValue());
+                    value = BigDecimal.valueOf(((Number) obj).longValue());
                 }
             } else if (obj instanceof Boolean) {
                 value = new BigDecimal(((Boolean) obj) ? 1 : 0);

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/types/ArithTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/types/ArithTest.java
@@ -40,7 +40,7 @@ public class ArithTest {
 
     @Test
     public void testAddBigDecimalWithBigDecimalOutput() {
-        Assert.assertEquals(new BigDecimal(20), Arith.add(new BigDecimal(10.0), new BigDecimal(10.0), BigDecimalType.TYPE));
+        Assert.assertEquals(BigDecimal.valueOf(20), Arith.add(BigDecimal.valueOf(10.0), BigDecimal.valueOf(10.0), BigDecimalType.TYPE));
     }
 
     @Test
@@ -50,12 +50,12 @@ public class ArithTest {
 
     @Test
     public void testAddDoubleWithDoubleOutput() {
-        Assert.assertEquals(new Double(20), Arith.add(new Double(10), new Double(10), DoubleType.TYPE));
+        Assert.assertEquals(Double.valueOf(20), Arith.add(Double.valueOf(10), Double.valueOf(10), DoubleType.TYPE));
     }
 
     @Test
     public void testAddLongWithLongOutput() {
-        Assert.assertEquals(new Long(20), Arith.add(new Long(10), new Long(10), IntegerType.TYPE));
+        Assert.assertEquals(Long.valueOf(20), Arith.add(Long.valueOf(10), Long.valueOf(10), IntegerType.TYPE));
     }
 
     @Test

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/types/BigDecimalTypeTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/types/BigDecimalTypeTest.java
@@ -88,7 +88,7 @@ public class BigDecimalTypeTest {
     public void testFromJsonStr() {
         JsonNode jsonNode = JsonNodeFactory.instance.textNode("100");
         Object fromJson = bigDecimalType.fromJson(jsonNode);
-        assertEquals(new BigDecimal(100.0),fromJson);
+        assertEquals(BigDecimal.valueOf(100.0),fromJson);
     }
 
     @Test(expected = Error.class)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Findbugs rule DM_NUMBER_CTOR - “ Method invokes inefficient Number constructor; use static valueOf instead ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#DM_NUMBER_CTOR
Please let me know if you have any questions.
Ayman Abdelghany.