### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/CrudConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/CrudConfiguration.java
@@ -89,7 +89,7 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
      * Validate that the configuration has all data needed.
      */
     public boolean isValid() {
-        return (controllers != null && controllers.length > 0);
+        return controllers != null && controllers.length > 0;
     }
 
     @Override

--- a/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldBinding.java
+++ b/crud/src/main/java/com/redhat/lightblue/assoc/ResolvedFieldBinding.java
@@ -198,7 +198,7 @@ public class ResolvedFieldBinding implements Serializable {
             while(fmd!=null&&fmd.getEntityPath().numSegments()>arrayName.numSegments())
                 fmd=fmd.getParent();
             CompositeMetadata arrayMd=fmd;
-            LOGGER.debug("Array metadata:{}",(arrayMd == null ? null : arrayMd.getName()));
+            LOGGER.debug("Array metadata:{}",arrayMd == null ? null : arrayMd.getName());
 
             Path absoluteArray;
             if(conjunct.isRequestQuery()) {

--- a/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/CompositeFindImpl.java
@@ -247,8 +247,8 @@ public class CompositeFindImpl implements Finder {
 
         if(rootDocs != null && ctx.hasErrors())
             rootDocs.clear();
-        LOGGER.debug("Root docs:{}",(rootDocs == null ? 0 : rootDocs.size()));
-        List<DocCtx> resultDocuments=new ArrayList<>((rootDocs == null ? 0 : rootDocs.size()));
+        LOGGER.debug("Root docs:{}",rootDocs == null ? 0 : rootDocs.size());
+        List<DocCtx> resultDocuments=new ArrayList<>(rootDocs == null ? 0 : rootDocs.size());
         if (rootDocs != null) {
             for(ResultDoc dgd:rootDocs) {
                 retrieveFragments(dgd);

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -457,7 +457,7 @@ public class Mediator {
                     ctx.setStatus(OperationStatus.ERROR);
                 }
 
-                response.setMatchCount((result == null ? 0 : result.getSize()));
+                response.setMatchCount(result == null ? 0 : result.getSize());
                 List<DocCtx> documents = ctx.getDocuments();
                 if (documents != null) {
                     List<JsonDoc> resultList = new ArrayList<>(documents.size());

--- a/metadata/src/main/java/com/redhat/lightblue/metadata/types/BooleanType.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/types/BooleanType.java
@@ -70,7 +70,7 @@ public final class BooleanType implements Type, Serializable {
         Boolean value = null;
         if (obj != null) {
             if (obj instanceof Boolean) {
-                value = ((Boolean) obj);
+                value = (Boolean) obj;
             } else if (obj instanceof Number) {
                 value = ((Number) obj).intValue() != 0;
             } else if (obj instanceof String) {

--- a/util/src/main/java/com/redhat/lightblue/util/DefaultRegistry.java
+++ b/util/src/main/java/com/redhat/lightblue/util/DefaultRegistry.java
@@ -54,7 +54,7 @@ public class DefaultRegistry<K, V> implements Registry<K, V>, Serializable {
         while (it.hasNext()) {
             Map.Entry pair = (Map.Entry)it.next();
             if(!items.containsKey(pair.getKey())){
-                items.put(((K)pair.getKey()),((V)pair.getValue()));
+                items.put((K)pair.getKey(), (V)pair.getValue());
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “  Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.