### PR TITLE
return a 0 list size if the passed in list is null

### DIFF
--- a/metadata/src/main/java/com/redhat/lightblue/metadata/parser/JSONMetadataParser.java
+++ b/metadata/src/main/java/com/redhat/lightblue/metadata/parser/JSONMetadataParser.java
@@ -85,6 +85,9 @@ public class JSONMetadataParser extends MetadataParser<JsonNode> {
 
     @Override
     public int getListSize(JsonNode list) {
+        if (list == null) {
+            return 0;
+        }
         return ((ArrayNode) list).size();
     }
 


### PR DESCRIPTION
Seems that a 0 integer should be returned if a null object is passed in.