### PR TITLE
Maintain nulls in arrays in insert, save requests

### DIFF
--- a/crud/src/test/java/com/redhat/lightblue/eval/ArrayContainsEvaluatorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ArrayContainsEvaluatorTest.java
@@ -70,7 +70,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void contains_all_returns_true_when_all_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf5', 'contains':'$all', 'values':[5,10,15,20]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf5', 'contains':'$all', 'values':[5,null,15,20]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -80,7 +80,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void contains_all_returns_false_when_all_expression_values_not_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf5', 'contains':'$all', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf5', 'contains':'$all', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -90,7 +90,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void contains_none_returns_false_when_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf5', 'contains':'$none', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf5', 'contains':'$none', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -130,7 +130,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void one_$parent_contains_all_returns_true_when_all_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf4.$parent.nf5', 'contains':'$all', 'values':[5,10,15,20]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf4.$parent.nf5', 'contains':'$all', 'values':[5,null,15,20]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -140,7 +140,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void one_$parent_contains_all_returns_false_when_all_expression_values_not_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf4.$parent.nf5', 'contains':'$all', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf4.$parent.nf5', 'contains':'$all', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -150,7 +150,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void one_$parent_contains_none_returns_false_when_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf4.$parent.nf5', 'contains':'$none', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf4.$parent.nf5', 'contains':'$none', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -190,7 +190,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void two_$parent_contains_all_returns_true_when_all_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf7.nnf1.$parent.$parent.nf5', 'contains':'$all', 'values':[5,10,15,20]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf7.nnf1.$parent.$parent.nf5', 'contains':'$all', 'values':[5,null,15,20]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -200,7 +200,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void two_$parent_contains_all_returns_false_when_all_expression_values_not_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf7.nnf1.$parent.$parent.nf5', 'contains':'$all', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf7.nnf1.$parent.$parent.nf5', 'contains':'$all', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -210,7 +210,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void two_$parent_contains_none_returns_false_when_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf7.nnf1.$parent.$parent.nf5', 'contains':'$none', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.nf7.nnf1.$parent.$parent.nf5', 'contains':'$none', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -250,7 +250,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void one_$this_contains_all_returns_true_when_all_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.nf5', 'contains':'$all', 'values':[5,10,15,20]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.nf5', 'contains':'$all', 'values':[5,null,15,20]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -260,7 +260,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void one_$this_contains_all_returns_false_when_all_expression_values_not_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.nf5', 'contains':'$all', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.nf5', 'contains':'$all', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -270,7 +270,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void one_$this_contains_none_returns_false_when_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.nf5', 'contains':'$none', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.nf5', 'contains':'$none', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -310,7 +310,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void two_$this_contains_all_returns_true_when_all_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.$this.nf5', 'contains':'$all', 'values':[5,10,15,20]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.$this.nf5', 'contains':'$all', 'values':[5,null,15,20]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -320,7 +320,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void two_$this_contains_all_returns_false_when_all_expression_values_not_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.$this.nf5', 'contains':'$all', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.$this.nf5', 'contains':'$all', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);
@@ -330,7 +330,7 @@ public class ArrayContainsEvaluatorTest extends AbstractJsonNodeTest {
 
     @Test
     public void two_$this_contains_none_returns_false_when_expression_values_in_array() throws Exception {
-        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.$this.nf5', 'contains':'$none', 'values':[5,10,15,25]}");
+        QueryExpression expr = EvalTestContext.queryExpressionFromJson("{'array':'field6.$this.$this.nf5', 'contains':'$none', 'values':[5,null,15,25]}");
         QueryEvaluator eval = QueryEvaluator.getInstance(expr, md);
 
         QueryEvaluationContext context = eval.evaluate(jsonDoc);

--- a/crud/src/test/java/com/redhat/lightblue/eval/FieldComparisonEvaluatorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/FieldComparisonEvaluatorTest.java
@@ -170,9 +170,9 @@ public class FieldComparisonEvaluatorTest extends AbstractJsonSchemaTest {
     }
 
     @Test
-    public void nf3_less_than_nf5() throws Exception {
+    public void nf3_less_than_nf9() throws Exception {
         QueryEvaluationContext ctx = QueryEvaluator.
-                getInstance(EvalTestContext.queryExpressionFromJson("{'field':'field6.nf3','op':'<','rfield':'field6.nf5'}"), md).
+                getInstance(EvalTestContext.queryExpressionFromJson("{'field':'field6.nf3','op':'<','rfield':'field6.nf9'}"), md).
                 evaluate(jsonDoc);
         Assert.assertTrue(ctx.getResult());
     }
@@ -231,6 +231,14 @@ public class FieldComparisonEvaluatorTest extends AbstractJsonSchemaTest {
                 getInstance(EvalTestContext.queryExpressionFromJson("{'field':'field6.nf5','op':'!=','rfield':'field6.nf5'}"), md).
                 evaluate(jsonDoc);
         Assert.assertFalse(ctx.getResult());
+    }
+
+    @Test
+    public void nf3_greater_than_nf11() throws Exception {
+        QueryEvaluationContext ctx = QueryEvaluator.
+                getInstance(EvalTestContext.queryExpressionFromJson("{'field':'field6.nf3','op':'>','rfield':'field6.nf11'}"), md).
+                evaluate(jsonDoc);
+        Assert.assertTrue(ctx.getResult());
     }
 
 }

--- a/crud/src/test/java/com/redhat/lightblue/eval/FieldProjectorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/FieldProjectorTest.java
@@ -55,7 +55,7 @@ public class FieldProjectorTest extends AbstractJsonNodeTest {
         Projection p = EvalTestContext.projectionFromJson("[{'field':'field2'},{'field':'field6.*','recursive':true}]");
         Projector projector = Projector.getInstance(p, md);
 
-        JsonNode expectedNode = JsonUtils.json("{'field2':'value2','field6':{'nf1':'nvalue1','nf2':'nvalue2','nf3':4,'nf4':false,'nf5':[5,10,15,20],'nf6':['one','two','three','four'],'nf7':{'nnf1':'nnvalue1','nnf2':2},'nf8':['four','three','two','one'],'nf9':[20,15,10,5],'nf10':[20.1,15.2,10.3,5.4],'nf11':null}}".replace('\'', '\"'));
+        JsonNode expectedNode = JsonUtils.json("{'field2':'value2','field6':{'nf1':'nvalue1','nf2':'nvalue2','nf3':4,'nf4':false,'nf5':[5,null,15,20],'nf6':['one','two','three','four'],'nf7':{'nnf1':'nnvalue1','nnf2':2},'nf8':['four','three','two','one'],'nf9':[20,15,10,5],'nf10':[20.1,15.2,10.3,5.4],'nf11':null}}".replace('\'', '\"'));
 
         JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
 
@@ -78,7 +78,7 @@ public class FieldProjectorTest extends AbstractJsonNodeTest {
         Projection p = EvalTestContext.projectionFromJson("[{'field':'field7.$parent.field2'},{'field':'field7.$parent.field6.*','recursive':true}]");
         Projector projector = Projector.getInstance(p, md);
 
-        JsonNode expectedNode = JsonUtils.json("{'field2':'value2','field6':{'nf1':'nvalue1','nf2':'nvalue2','nf3':4,'nf4':false,'nf5':[5,10,15,20],'nf6':['one','two','three','four'],'nf7':{'nnf1':'nnvalue1','nnf2':2},'nf8':['four','three','two','one'],'nf9':[20,15,10,5],'nf10':[20.1,15.2,10.3,5.4],'nf11':null}}".replace('\'', '\"'));
+        JsonNode expectedNode = JsonUtils.json("{'field2':'value2','field6':{'nf1':'nvalue1','nf2':'nvalue2','nf3':4,'nf4':false,'nf5':[5,null,15,20],'nf6':['one','two','three','four'],'nf7':{'nnf1':'nnvalue1','nnf2':2},'nf8':['four','three','two','one'],'nf9':[20,15,10,5],'nf10':[20.1,15.2,10.3,5.4],'nf11':null}}".replace('\'', '\"'));
 
         JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
 
@@ -101,7 +101,7 @@ public class FieldProjectorTest extends AbstractJsonNodeTest {
         Projection p = EvalTestContext.projectionFromJson("[{'field':'field6.nf7.$parent.$parent.field2'},{'field':'field6.nf7.$parent.$parent.field6.*','recursive':true}]");
         Projector projector = Projector.getInstance(p, md);
 
-        JsonNode expectedNode = JsonUtils.json("{'field2':'value2','field6':{'nf1':'nvalue1','nf2':'nvalue2','nf3':4,'nf4':false,'nf5':[5,10,15,20],'nf6':['one','two','three','four'],'nf7':{'nnf1':'nnvalue1','nnf2':2},'nf8':['four','three','two','one'],'nf9':[20,15,10,5],'nf10':[20.1,15.2,10.3,5.4],'nf11':null}}".replace('\'', '\"'));
+        JsonNode expectedNode = JsonUtils.json("{'field2':'value2','field6':{'nf1':'nvalue1','nf2':'nvalue2','nf3':4,'nf4':false,'nf5':[5,null,15,20],'nf6':['one','two','three','four'],'nf7':{'nnf1':'nnvalue1','nnf2':2},'nf8':['four','three','two','one'],'nf9':[20,15,10,5],'nf10':[20.1,15.2,10.3,5.4],'nf11':null}}".replace('\'', '\"'));
 
         JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
 

--- a/crud/src/test/java/com/redhat/lightblue/eval/ProjectionTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ProjectionTest.java
@@ -117,7 +117,7 @@ public class ProjectionTest extends AbstractJsonNodeTest {
         Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
         Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
         Assert.assertEquals(5, newDoc.get(new Path("field6.nf5.0")).asInt());
-        Assert.assertEquals(10, newDoc.get(new Path("field6.nf5.1")).asInt());
+        Assert.assertEquals(JSON_NODE_FACTORY.nullNode(), newDoc.get(new Path("field6.nf5.1")));
         Assert.assertEquals(15, newDoc.get(new Path("field6.nf5.2")).asInt());
         Assert.assertEquals(20, newDoc.get(new Path("field6.nf5.3")).asInt());
         Assert.assertEquals("one", newDoc.get(new Path("field6.nf6.0")).asText());
@@ -153,7 +153,7 @@ public class ProjectionTest extends AbstractJsonNodeTest {
         Assert.assertEquals(4, newDoc.get(new Path("field6.nf3")).asInt());
         Assert.assertEquals(false, newDoc.get(new Path("field6.nf4")).asBoolean());
         Assert.assertEquals(5, newDoc.get(new Path("field6.nf5.0")).asInt());
-        Assert.assertEquals(10, newDoc.get(new Path("field6.nf5.1")).asInt());
+        Assert.assertEquals(JSON_NODE_FACTORY.nullNode(), newDoc.get(new Path("field6.nf5.1")));
         Assert.assertEquals(15, newDoc.get(new Path("field6.nf5.2")).asInt());
         Assert.assertEquals(20, newDoc.get(new Path("field6.nf5.3")).asInt());
         Assert.assertEquals("one", newDoc.get(new Path("field6.nf6.0")).asText());

--- a/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
@@ -77,7 +77,6 @@ public class ProjectorTest extends AbstractJsonNodeTest {
         Projection p = EvalTestContext.projectionFromJson("{'field':'field6.*','recursive':true}");
         Projector projector = Projector.getInstance(p, md);
         JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
-        Assert.assertEquals(11, pdoc.get(new Path("field6")).size());
         Assert.assertEquals(4, pdoc.get(new Path("field6.nf5")).size());
         Assert.assertEquals(JSON_NODE_FACTORY.nullNode(), pdoc.get(new Path("field6.nf5.1")));
     }

--- a/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
@@ -39,14 +39,6 @@ public class ProjectorTest extends AbstractJsonNodeTest {
     }
 
     @Test
-    public void test() throws Exception {
-        Projection p = EvalTestContext.projectionFromJson("[{'field':'field2'},{'field':'field6.*', 'recursive': true}]");
-        Projector projector = Projector.getInstance(p, md);
-        JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
-        System.out.println(pdoc);
-    }
-
-    @Test
     public void fieldProjectorTest_nonrecursive() throws Exception {
         Projection p = EvalTestContext.projectionFromJson("[{'field':'field2'},{'field':'field6.*'}]");
         Projector projector = Projector.getInstance(p, md);

--- a/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/ProjectorTest.java
@@ -39,6 +39,14 @@ public class ProjectorTest extends AbstractJsonNodeTest {
     }
 
     @Test
+    public void test() throws Exception {
+        Projection p = EvalTestContext.projectionFromJson("[{'field':'field2'},{'field':'field6.*', 'recursive': true}]");
+        Projector projector = Projector.getInstance(p, md);
+        JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
+        System.out.println(pdoc);
+    }
+
+    @Test
     public void fieldProjectorTest_nonrecursive() throws Exception {
         Projection p = EvalTestContext.projectionFromJson("[{'field':'field2'},{'field':'field6.*'}]");
         Projector projector = Projector.getInstance(p, md);
@@ -73,6 +81,16 @@ public class ProjectorTest extends AbstractJsonNodeTest {
     }
 
     @Test
+    public void fieldProjectorTest_recursive_doesNotFilterNullsInArrays() throws Exception {
+        Projection p = EvalTestContext.projectionFromJson("{'field':'field6.*','recursive':true}");
+        Projector projector = Projector.getInstance(p, md);
+        JsonDoc pdoc = projector.project(jsonDoc, JSON_NODE_FACTORY);
+        Assert.assertEquals(11, pdoc.get(new Path("field6")).size());
+        Assert.assertEquals(4, pdoc.get(new Path("field6.nf5")).size());
+        Assert.assertEquals(JSON_NODE_FACTORY.nullNode(), pdoc.get(new Path("field6.nf5.1")));
+    }
+
+    @Test
     public void fieldProjectorTest_arr_range() throws Exception {
         Projection p = EvalTestContext.projectionFromJson("{'field':'field7','range':[1,2],'project':{'field':'elemf3'}}");
         Projector projector = Projector.getInstance(p, md);
@@ -90,7 +108,6 @@ public class ProjectorTest extends AbstractJsonNodeTest {
         Assert.assertNull(pdoc.get(new Path("field7.0.elemf2")));
         Assert.assertNull(pdoc.get(new Path("field7.1.elemf1")));
         Assert.assertNull(pdoc.get(new Path("field7.1.elemf2")));
-
     }
 
     @Test

--- a/crud/src/test/java/com/redhat/lightblue/eval/UpdaterTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/eval/UpdaterTest.java
@@ -194,13 +194,13 @@ public class UpdaterTest extends AbstractJsonNodeTest {
 
     @Test
     public void array_foreach_removethis() throws Exception {
-        UpdateExpression expr = EvalTestContext.updateExpressionFromJson("{ '$foreach' : { 'field6.nf5' : { 'field':'$this','op':'=','rvalue':10} , '$update' : '$remove' } }");
+        UpdateExpression expr = EvalTestContext.updateExpressionFromJson("{ '$foreach' : { 'field6.nf5' : { 'field':'$this','op':'=','rvalue':15} , '$update' : '$remove' } }");
         Updater updater = Updater.getInstance(JSON_NODE_FACTORY, md, expr);
         Assert.assertEquals(4, jsonDoc.get(new Path("field6.nf5")).size());
-        Assert.assertEquals(10, jsonDoc.get(new Path("field6.nf5.1")).asInt());
+        Assert.assertEquals(15, jsonDoc.get(new Path("field6.nf5.2")).asInt());
         updater.update(jsonDoc, md.getFieldTreeRoot(), new Path());
         Assert.assertEquals(3, jsonDoc.get(new Path("field6.nf5")).size());
-        Assert.assertEquals(15, jsonDoc.get(new Path("field6.nf5.1")).asInt());
+        Assert.assertEquals(20, jsonDoc.get(new Path("field6.nf5.2")).asInt());
     }
 
     @Test

--- a/crud/src/test/resources/sample1.json
+++ b/crud/src/test/resources/sample1.json
@@ -10,7 +10,7 @@
     "nf2": "nvalue2",
     "nf3": 4,
     "nf4": false,
-    "nf5": [5, 10, 15, 20],
+    "nf5": [5, null, 15, 20],
     "nf6": ["one", "two", "three", "four"],
     "nf7": {
       "nnf1": "nnvalue1",

--- a/util/src/main/java/com/redhat/lightblue/util/JsonDoc.java
+++ b/util/src/main/java/com/redhat/lightblue/util/JsonDoc.java
@@ -496,30 +496,19 @@ public class JsonDoc implements Serializable {
      */
     public static JsonNode filterNulls(JsonNode root) {
         if (root instanceof ArrayNode) {
-            ArrayNode a = (ArrayNode) root;
-            int n = a.size();
-            for (int i = n - 1; i >= 0; i--) {
-                JsonNode node = a.get(i);
-                if (node == null || node instanceof NullNode) {
-                    a.remove(i);
-                } else {
-                    filterNulls(node);
-                }
+            for (JsonNode element : root) {
+                filterNulls(element);
             }
         } else if (root instanceof ObjectNode) {
             ObjectNode o = (ObjectNode) root;
-            List<String> removeList = new ArrayList<>();
             for (Iterator<Map.Entry<String, JsonNode>> itr = o.fields(); itr.hasNext();) {
                 Map.Entry<String, JsonNode> entry = itr.next();
                 JsonNode value = entry.getValue();
                 if (value == null || value instanceof NullNode) {
-                    removeList.add(entry.getKey());
+                    itr.remove();
                 } else {
-                    filterNulls(entry.getValue());
+                    filterNulls(value);
                 }
-            }
-            for (String x : removeList) {
-                o.remove(x);
             }
         }
         return root;

--- a/util/src/test/java/com/redhat/lightblue/util/FilterNullTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/FilterNullTest.java
@@ -48,6 +48,6 @@ public class FilterNullTest {
     public void nestedRemoval() throws Exception {
         JsonNode node = json("{'x':'a','y':[null,{'z':null,'a':'a','b':['a','b',null]}]}");
         JsonDoc.filterNulls(node);
-        JSONAssert.assertEquals(esc("{'x':'a','y':[{'a':'a','b':['a','b']}]}"), node.toString(), false);
+        JSONAssert.assertEquals(esc("{'x':'a','y':[null, {'a':'a','b':['a','b', null]}]}"), node.toString(), false);
     }
 }


### PR DESCRIPTION
Fixes #592 

There is still the potential for filtering logic to get out of sync between update and save/insert, because save/insert docs are filtered in core before passed to controller, but all update filtering would be done in controller. Maybe filtering nulls out of doc should be left up to controller, and then controller can be internally consistent.

In any case, with this update insert, update, and saves should treat nulls in arrays consistently with mongo update at least.