### PR TITLE
Poor man's profiling

### DIFF
--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>json-schema-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-aspects</artifactId>
+            <version>0.22.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
@@ -91,5 +96,31 @@
          </dependency>
    </dependencies>
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.10</version>
+                <configuration>
+                    <complianceLevel>1.8</complianceLevel>
+                    <verbose>true</verbose>
+                    <aspectLibraries>
+                        <aspectLibrary>
+                            <groupId>com.jcabi</groupId>
+                            <artifactId>jcabi-aspects</artifactId>
+                        </aspectLibrary>
+                    </aspectLibraries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>weave-classes</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Iterator;
 
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Callable;
@@ -32,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.jcabi.aspects.Loggable;
 import com.redhat.lightblue.OperationStatus;
 import com.redhat.lightblue.Request;
 import com.redhat.lightblue.Response;
@@ -117,6 +119,7 @@ public class Mediator {
      * that pass the validation to the CRUD implementation for that entity. CRUD
      * implementation can perform further validations.
      */
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response insert(InsertionRequest req) {
         LOGGER.debug("insert {}", req.getEntityVersion());
         Error.push("insert(" + req.getEntityVersion().toString() + ")");
@@ -190,6 +193,7 @@ public class Mediator {
      * implementation can perform further validations.
      *
      */
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response save(SaveRequest req) {
         LOGGER.debug("save {}", req.getEntityVersion());
         Error.push("save(" + req.getEntityVersion().toString() + ")");
@@ -264,6 +268,7 @@ public class Mediator {
      * implementation must perform all constraint validations and process only
      * the documents that pass those validations.
      */
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response update(UpdateRequest req) {
         LOGGER.debug("update {}", req.getEntityVersion());
         Error.push("update(" + req.getEntityVersion().toString() + ")");
@@ -337,6 +342,7 @@ public class Mediator {
         return response;
     }
 
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response delete(DeleteRequest req) {
         LOGGER.debug("delete {}", req.getEntityVersion());
         Error.push("delete(" + req.getEntityVersion().toString() + ")");
@@ -472,6 +478,7 @@ public class Mediator {
      *
      * The implementation passes the request to the back-end.
      */
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response find(FindRequest req) {
         LOGGER.debug("find {}", req.getEntityVersion());
         Error.push("find(" + req.getEntityVersion().toString() + ")");
@@ -557,6 +564,7 @@ public class Mediator {
      * the core level, and then passed to the backend to fill in
      * back-end specifics
      */
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response explain(FindRequest req) {
         LOGGER.debug("explain {}", req.getEntityVersion());
         Error.push("explain(" + req.getEntityVersion().toString() + ")");

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -21,7 +21,6 @@ package com.redhat.lightblue.mediator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Iterator;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -119,7 +118,7 @@ public class Mediator {
      * that pass the validation to the CRUD implementation for that entity. CRUD
      * implementation can perform further validations.
      */
-    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response insert(InsertionRequest req) {
         LOGGER.debug("insert {}", req.getEntityVersion());
         Error.push("insert(" + req.getEntityVersion().toString() + ")");
@@ -193,7 +192,7 @@ public class Mediator {
      * implementation can perform further validations.
      *
      */
-    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response save(SaveRequest req) {
         LOGGER.debug("save {}", req.getEntityVersion());
         Error.push("save(" + req.getEntityVersion().toString() + ")");
@@ -268,7 +267,7 @@ public class Mediator {
      * implementation must perform all constraint validations and process only
      * the documents that pass those validations.
      */
-    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response update(UpdateRequest req) {
         LOGGER.debug("update {}", req.getEntityVersion());
         Error.push("update(" + req.getEntityVersion().toString() + ")");
@@ -342,7 +341,7 @@ public class Mediator {
         return response;
     }
 
-    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response delete(DeleteRequest req) {
         LOGGER.debug("delete {}", req.getEntityVersion());
         Error.push("delete(" + req.getEntityVersion().toString() + ")");
@@ -478,7 +477,7 @@ public class Mediator {
      *
      * The implementation passes the request to the back-end.
      */
-    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response find(FindRequest req) {
         LOGGER.debug("find {}", req.getEntityVersion());
         Error.push("find(" + req.getEntityVersion().toString() + ")");
@@ -564,7 +563,7 @@ public class Mediator {
      * the core level, and then passed to the backend to fill in
      * back-end specifics
      */
-    @Loggable(limit=5, unit=TimeUnit.SECONDS, value=Loggable.WARN, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @Loggable(limit=5, unit=TimeUnit.SECONDS, trim=false, skipResult=true, name="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response explain(FindRequest req) {
         LOGGER.debug("explain {}", req.getEntityVersion());
         Error.push("explain(" + req.getEntityVersion().toString() + ")");


### PR DESCRIPTION
A very simple and unintrusive logging of crud operations which take more than 5 seconds, in lieu of proper profiling instrumentation. Main purpose is to be able to see inside bulk operations.

Here is how a log line looks:

```
[main] WARN stopwatch.com.redhat.lightblue.mediator.Mediator - #find({"entity":"A","entityVersion":"1.0.0","op":"FIND","query":{"field":"obj1.c.*.field1","op":"$eq","rvalue"
:"ABFPwrjyx-o5DQWWZmSEfKf3W1z"},"projection":[{"field":"*","include":true,"recursive":true} in 3.04ms
```

There is no way to configure this without recompilation (except configuring the logger to stop logging this).
