### PR TITLE
Poor man's profiling - custom solution

### DIFF
--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -91,5 +91,31 @@
          </dependency>
    </dependencies>
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.10</version>
+                <configuration>
+                    <complianceLevel>1.8</complianceLevel>
+                    <verbose>true</verbose>
+                    <aspectLibraries>
+                        <aspectLibrary>
+                            <groupId>com.redhat.lightblue</groupId>
+                            <artifactId>lightblue-core-util</artifactId>
+                        </aspectLibrary>
+                    </aspectLibraries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>weave-classes</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -115,7 +115,7 @@ public class Mediator {
      * that pass the validation to the CRUD implementation for that entity. CRUD
      * implementation can perform further validations.
      */
-    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @StopWatch(loggerName = "stopwatch.com.redhat.lightblue.mediator.Mediator", sizeCalculatorClass = "com.redhat.lightblue.mediator.ResponsePayloadSizeCalculator")
     public Response insert(InsertionRequest req) {
         LOGGER.debug("insert {}", req.getEntityVersion());
         Error.push("insert(" + req.getEntityVersion().toString() + ")");
@@ -189,7 +189,7 @@ public class Mediator {
      * implementation can perform further validations.
      *
      */
-    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @StopWatch(loggerName = "stopwatch.com.redhat.lightblue.mediator.Mediator", sizeCalculatorClass = "com.redhat.lightblue.mediator.ResponsePayloadSizeCalculator")
     public Response save(SaveRequest req) {
         LOGGER.debug("save {}", req.getEntityVersion());
         Error.push("save(" + req.getEntityVersion().toString() + ")");
@@ -264,7 +264,7 @@ public class Mediator {
      * implementation must perform all constraint validations and process only
      * the documents that pass those validations.
      */
-    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @StopWatch(loggerName = "stopwatch.com.redhat.lightblue.mediator.Mediator", sizeCalculatorClass = "com.redhat.lightblue.mediator.ResponsePayloadSizeCalculator")
     public Response update(UpdateRequest req) {
         LOGGER.debug("update {}", req.getEntityVersion());
         Error.push("update(" + req.getEntityVersion().toString() + ")");
@@ -338,7 +338,7 @@ public class Mediator {
         return response;
     }
 
-    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @StopWatch(loggerName = "stopwatch.com.redhat.lightblue.mediator.Mediator", sizeCalculatorClass = "com.redhat.lightblue.mediator.ResponsePayloadSizeCalculator")
     public Response delete(DeleteRequest req) {
         LOGGER.debug("delete {}", req.getEntityVersion());
         Error.push("delete(" + req.getEntityVersion().toString() + ")");
@@ -474,7 +474,7 @@ public class Mediator {
      *
      * The implementation passes the request to the back-end.
      */
-    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @StopWatch(loggerName = "stopwatch.com.redhat.lightblue.mediator.Mediator", sizeCalculatorClass = "com.redhat.lightblue.mediator.ResponsePayloadSizeCalculator")
     public Response find(FindRequest req) {
         LOGGER.debug("find {}", req.getEntityVersion());
         Error.push("find(" + req.getEntityVersion().toString() + ")");
@@ -560,7 +560,7 @@ public class Mediator {
      * the core level, and then passed to the backend to fill in
      * back-end specifics
      */
-    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
+    @StopWatch(loggerName = "stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response explain(FindRequest req) {
         LOGGER.debug("explain {}", req.getEntityVersion());
         Error.push("explain(" + req.getEntityVersion().toString() + ")");

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -21,46 +21,45 @@ package com.redhat.lightblue.mediator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Iterator;
-
-import java.util.concurrent.Future;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.DataError;
 import com.redhat.lightblue.OperationStatus;
 import com.redhat.lightblue.Request;
 import com.redhat.lightblue.Response;
-import com.redhat.lightblue.DataError;
 import com.redhat.lightblue.ResultMetadata;
+import com.redhat.lightblue.assoc.AnalyzeQuery;
+import com.redhat.lightblue.assoc.CompositeFindImpl;
+import com.redhat.lightblue.assoc.QueryFieldInfo;
 import com.redhat.lightblue.crud.BulkRequest;
 import com.redhat.lightblue.crud.BulkResponse;
 import com.redhat.lightblue.crud.CRUDController;
 import com.redhat.lightblue.crud.CRUDDeleteResponse;
-import com.redhat.lightblue.crud.CRUDInsertionResponse;
 import com.redhat.lightblue.crud.CRUDFindResponse;
-import com.redhat.lightblue.crud.CRUDSaveResponse;
+import com.redhat.lightblue.crud.CRUDInsertionResponse;
 import com.redhat.lightblue.crud.CRUDOperation;
+import com.redhat.lightblue.crud.CRUDSaveResponse;
 import com.redhat.lightblue.crud.CRUDUpdateResponse;
 import com.redhat.lightblue.crud.ConstraintValidator;
 import com.redhat.lightblue.crud.CrudConstants;
 import com.redhat.lightblue.crud.DeleteRequest;
 import com.redhat.lightblue.crud.DocCtx;
+import com.redhat.lightblue.crud.DocumentStream;
 import com.redhat.lightblue.crud.Factory;
 import com.redhat.lightblue.crud.FindRequest;
 import com.redhat.lightblue.crud.InsertionRequest;
 import com.redhat.lightblue.crud.SaveRequest;
 import com.redhat.lightblue.crud.UpdateRequest;
-import com.redhat.lightblue.crud.DocumentStream;
+import com.redhat.lightblue.crud.WithIfCurrent;
 import com.redhat.lightblue.crud.WithQuery;
 import com.redhat.lightblue.crud.WithRange;
-import com.redhat.lightblue.crud.WithIfCurrent;
-import com.redhat.lightblue.assoc.AnalyzeQuery;
-import com.redhat.lightblue.assoc.QueryFieldInfo;
 import com.redhat.lightblue.eval.FieldAccessRoleEvaluator;
 import com.redhat.lightblue.interceptor.InterceptPoint;
 import com.redhat.lightblue.metadata.CompositeMetadata;
@@ -81,8 +80,7 @@ import com.redhat.lightblue.query.ValueComparisonExpression;
 import com.redhat.lightblue.util.Error;
 import com.redhat.lightblue.util.JsonDoc;
 import com.redhat.lightblue.util.Path;
-
-import com.redhat.lightblue.assoc.CompositeFindImpl;
+import com.redhat.lightblue.util.stopwatch.StopWatch;
 
 /**
  * The mediator looks at a request, performs basic validation, and passes the
@@ -117,6 +115,7 @@ public class Mediator {
      * that pass the validation to the CRUD implementation for that entity. CRUD
      * implementation can perform further validations.
      */
+    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response insert(InsertionRequest req) {
         LOGGER.debug("insert {}", req.getEntityVersion());
         Error.push("insert(" + req.getEntityVersion().toString() + ")");
@@ -190,6 +189,7 @@ public class Mediator {
      * implementation can perform further validations.
      *
      */
+    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response save(SaveRequest req) {
         LOGGER.debug("save {}", req.getEntityVersion());
         Error.push("save(" + req.getEntityVersion().toString() + ")");
@@ -264,6 +264,7 @@ public class Mediator {
      * implementation must perform all constraint validations and process only
      * the documents that pass those validations.
      */
+    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response update(UpdateRequest req) {
         LOGGER.debug("update {}", req.getEntityVersion());
         Error.push("update(" + req.getEntityVersion().toString() + ")");
@@ -337,6 +338,7 @@ public class Mediator {
         return response;
     }
 
+    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response delete(DeleteRequest req) {
         LOGGER.debug("delete {}", req.getEntityVersion());
         Error.push("delete(" + req.getEntityVersion().toString() + ")");
@@ -472,6 +474,7 @@ public class Mediator {
      *
      * The implementation passes the request to the back-end.
      */
+    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response find(FindRequest req) {
         LOGGER.debug("find {}", req.getEntityVersion());
         Error.push("find(" + req.getEntityVersion().toString() + ")");
@@ -557,6 +560,7 @@ public class Mediator {
      * the core level, and then passed to the backend to fill in
      * back-end specifics
      */
+    @StopWatch(loggerName="stopwatch.com.redhat.lightblue.mediator.Mediator")
     public Response explain(FindRequest req) {
         LOGGER.debug("explain {}", req.getEntityVersion());
         Error.push("explain(" + req.getEntityVersion().toString() + ")");

--- a/crud/src/main/java/com/redhat/lightblue/mediator/ResponsePayloadSizeCalculator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/ResponsePayloadSizeCalculator.java
@@ -1,0 +1,14 @@
+package com.redhat.lightblue.mediator;
+
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.util.JsonUtils;
+import com.redhat.lightblue.util.stopwatch.SizeCalculator;
+
+public class ResponsePayloadSizeCalculator implements SizeCalculator<Response>{
+
+    @Override
+    public int size(Response response) {
+        return JsonUtils.size(response.getEntityData());
+    }
+
+}

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -73,5 +73,35 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>1.8.9</version>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.10</version>
+                <configuration>
+                    <complianceLevel>1.8</complianceLevel>
+                    <verbose>true</verbose>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>weave-classes</id>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <showWeaveInfo>true</showWeaveInfo>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/util/src/main/java/com/redhat/lightblue/util/JsonUtils.java
+++ b/util/src/main/java/com/redhat/lightblue/util/JsonUtils.java
@@ -443,6 +443,33 @@ public final class JsonUtils {
         }
     }
 
+    /**
+     * An approximation of how much space will a JsonNode take in memory. Does not take jvm optimizations
+     * or architecture into account. Useful only to compare JsonNodes with each other.
+     *
+     * @param node
+     * @return
+     */
+    public static int size(JsonNode node) {
+        int size = 0;
+        if (node instanceof ArrayNode) {
+            for (Iterator<JsonNode> elements = ((ArrayNode) node).elements(); elements.hasNext();) {
+                size += size(elements.next());
+            }
+        } else if (node instanceof ObjectNode) {
+            for (Iterator<Map.Entry<String, JsonNode>> fields = ((ObjectNode) node).fields(); fields.hasNext();) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                size += field.getKey().length();
+                size += size(field.getValue());
+            }
+        } else if (node instanceof NumericNode) {
+            size += 4;
+        } else {
+            size += node.asText().length();
+        }
+        return size;
+    }
+
     private JsonUtils() {
     }
 }

--- a/util/src/main/java/com/redhat/lightblue/util/JsonUtils.java
+++ b/util/src/main/java/com/redhat/lightblue/util/JsonUtils.java
@@ -451,6 +451,10 @@ public final class JsonUtils {
      * @return
      */
     public static int size(JsonNode node) {
+        if (node == null) {
+            return 0;
+        }
+
         int size = 0;
         if (node instanceof ArrayNode) {
             for (Iterator<JsonNode> elements = ((ArrayNode) node).elements(); elements.hasNext();) {

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/Mnemos.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/Mnemos.java
@@ -105,32 +105,6 @@ final class Mnemos {
     }
 
     /**
-     * Make a string out of point.
-     * @param point The point
-     * @param trim Shall we trim long texts?
-     * @return Text representation of it
-     * @deprecated Use toText(Method,Object,boolean,boolean) instead
-     */
-    @Deprecated
-    public static String toText(final ProceedingJoinPoint point,
-        final boolean trim) {
-        return Mnemos.toText(point, trim, false);
-    }
-
-    /**
-     * Make a string out of point.
-     * @param point The point
-     * @param trim Shall we trim long texts?
-     * @return Text representation of it
-     * @deprecated Use toText() instead
-     */
-    @Deprecated
-    public static String toString(final ProceedingJoinPoint point,
-        final boolean trim) {
-        return Mnemos.toText(point, trim, false);
-    }
-
-    /**
      * Make a string out of method.
      * @param method The method
      * @param args Actual arguments of the method
@@ -175,34 +149,6 @@ final class Mnemos {
     public static String toText(final Method method, final Object[] args,
         final boolean trim, final boolean skip) {
         return Mnemos.toText(method, args, "", trim, skip);
-    }
-
-    /**
-     * Make a string out of method.
-     * @param method The method
-     * @param args Actual arguments of the method
-     * @param trim Shall we trim long texts?
-     * @return Text representation of it
-     * @deprecated Use toText(Method,Object,boolean,boolean) instead
-     */
-    @Deprecated
-    public static String toText(final Method method, final Object[] args,
-        final boolean trim) {
-        return Mnemos.toText(method, args, trim, false);
-    }
-
-    /**
-     * Make a string out of method.
-     * @param method The method
-     * @param args Actual arguments of the method
-     * @param trim Shall we trim long texts?
-     * @return Text representation of it
-     * @deprecated Use toText() instead
-     */
-    @Deprecated
-    public static String toString(final Method method, final Object[] args,
-        final boolean trim) {
-        return Mnemos.toText(method, args, trim, false);
     }
 
     /**
@@ -253,30 +199,6 @@ final class Mnemos {
             }
         }
         return text.toString();
-    }
-
-    /**
-     * Make a string out of an object.
-     * @param arg The argument
-     * @param trim Shall we trim long texts?
-     * @return Text representation of it
-     * @deprecated Use toText(Object,boolean,boolean) instead
-     */
-    @Deprecated
-    public static String toText(final Object arg, final boolean trim) {
-        return Mnemos.toText(arg, trim, false);
-    }
-
-    /**
-     * Make a string out of an object.
-     * @param arg The argument
-     * @param trim Shall we trim long texts?
-     * @return Text representation of it
-     * @deprecated Use toText() instead
-     */
-    @Deprecated
-    public static String toString(final Object arg, final boolean trim) {
-        return Mnemos.toText(arg, trim, false);
     }
 
     /**

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/Mnemos.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/Mnemos.java
@@ -1,0 +1,352 @@
+// from https://github.com/jcabi/jcabi-aspects/blob/c0840e6c391db57e817920fce92f4fb4b9f38cb5/src/main/java/com/jcabi/aspects/aj/Mnemos.java
+
+/**
+ * Copyright (c) 2012-2017, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.redhat.lightblue.util.stopwatch;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+
+/**
+ * Utility class with text functions for making mnemos.
+ *
+ * @author Yegor Bugayenko (yegor@tpc2.com)
+ * @version $Id$
+ */
+@SuppressWarnings({ "PMD.TooManyMethods", "PMD.AvoidUsingShortType" })
+final class Mnemos {
+
+    /**
+     * Comma between elements.
+     */
+    private static final String COMMA = ", ";
+
+    /**
+     * Dots that skip.
+     */
+    private static final String DOTS = "...";
+
+    /**
+     * Private ctor, it's a utility class.
+     */
+    private Mnemos() {
+        // intentionally empty
+    }
+
+    /**
+     * Make a string out of point.
+     * @param point The point
+     * @param trim Shall we trim long texts?
+     * @param skip Shall we skip details and output just dots?
+     * @param logthis Shall we add toString result to log?
+     * @return Text representation of it
+     * @since 0.8.1
+     * @checkstyle ParameterNumber (3 lines)
+     */
+    public static String toText(final ProceedingJoinPoint point,
+        final boolean trim, final boolean skip, final boolean logthis) {
+        final String additional;
+        if (logthis && (point.getThis() != null)) {
+            additional = point.getThis().toString();
+        } else {
+            additional = "";
+        }
+        return Mnemos.toText(
+            MethodSignature.class.cast(point.getSignature()).getMethod(),
+            point.getArgs(), additional,
+            trim, skip
+        );
+    }
+    /**
+     * Make a string out of point.
+     * @param point The point
+     * @param trim Shall we trim long texts?
+     * @param skip Shall we skip details and output just dots?
+     * @return Text representation of it
+     * @since 0.7.19
+     */
+    public static String toText(final ProceedingJoinPoint point,
+        final boolean trim, final boolean skip) {
+        return Mnemos.toText(
+            MethodSignature.class.cast(point.getSignature()).getMethod(),
+            point.getArgs(),
+            trim, skip
+        );
+    }
+
+    /**
+     * Make a string out of point.
+     * @param point The point
+     * @param trim Shall we trim long texts?
+     * @return Text representation of it
+     * @deprecated Use toText(Method,Object,boolean,boolean) instead
+     */
+    @Deprecated
+    public static String toText(final ProceedingJoinPoint point,
+        final boolean trim) {
+        return Mnemos.toText(point, trim, false);
+    }
+
+    /**
+     * Make a string out of point.
+     * @param point The point
+     * @param trim Shall we trim long texts?
+     * @return Text representation of it
+     * @deprecated Use toText() instead
+     */
+    @Deprecated
+    public static String toString(final ProceedingJoinPoint point,
+        final boolean trim) {
+        return Mnemos.toText(point, trim, false);
+    }
+
+    /**
+     * Make a string out of method.
+     * @param method The method
+     * @param args Actual arguments of the method
+     * @param additional Additional text to add before log line
+     * @param trim Shall we trim long texts?
+     * @param skip Shall we skip details and output just dots?
+     * @return Text representation of it
+     * @since 0.8.1
+     * @checkstyle ParameterNumber (4 lines)
+     */
+    public static String toText(final Method method, final Object[] args,
+        final String additional, final boolean trim, final boolean skip) {
+        final StringBuilder log = new StringBuilder();
+        if (additional != null) {
+            log.append(additional);
+        }
+        log.append('#').append(method.getName()).append('(');
+        if (skip) {
+            log.append(Mnemos.DOTS);
+        } else {
+            for (int pos = 0; pos < args.length; ++pos) {
+                if (pos > 0) {
+                    log.append(Mnemos.COMMA);
+                }
+                log.append(Mnemos.toText(args[pos], trim, false));
+            }
+        }
+        log.append(')');
+        return log.toString();
+    }
+
+    /**
+     * Make a string out of method.
+     * @param method The method
+     * @param args Actual arguments of the method
+     * @param trim Shall we trim long texts?
+     * @param skip Shall we skip details and output just dots?
+     * @return Text representation of it
+     * @since 0.7.19
+     * @checkstyle ParameterNumber (4 lines)
+     */
+    public static String toText(final Method method, final Object[] args,
+        final boolean trim, final boolean skip) {
+        return Mnemos.toText(method, args, "", trim, skip);
+    }
+
+    /**
+     * Make a string out of method.
+     * @param method The method
+     * @param args Actual arguments of the method
+     * @param trim Shall we trim long texts?
+     * @return Text representation of it
+     * @deprecated Use toText(Method,Object,boolean,boolean) instead
+     */
+    @Deprecated
+    public static String toText(final Method method, final Object[] args,
+        final boolean trim) {
+        return Mnemos.toText(method, args, trim, false);
+    }
+
+    /**
+     * Make a string out of method.
+     * @param method The method
+     * @param args Actual arguments of the method
+     * @param trim Shall we trim long texts?
+     * @return Text representation of it
+     * @deprecated Use toText() instead
+     */
+    @Deprecated
+    public static String toString(final Method method, final Object[] args,
+        final boolean trim) {
+        return Mnemos.toText(method, args, trim, false);
+    }
+
+    /**
+     * Make a string out of an exception.
+     * @param exp The exception
+     * @return Text representation of it
+     */
+    public static String toText(final Throwable exp) {
+        final StringBuilder text = new StringBuilder();
+        text.append(exp.getClass().getName());
+        final String msg = exp.getMessage();
+        if (msg != null) {
+            text.append('(').append(msg).append(')');
+        }
+        return text.toString();
+    }
+
+    /**
+     * Make a string out of an object.
+     * @param arg The argument
+     * @param trim Shall we trim long texts?
+     * @param skip Shall we skip it with dots?
+     * @return Text representation of it
+     * @since 0.7.19
+     */
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    public static String toText(final Object arg, final boolean trim,
+        final boolean skip) {
+        final StringBuilder text = new StringBuilder();
+        if (arg == null) {
+            text.append("NULL");
+        } else if (skip) {
+            text.append(Mnemos.DOTS);
+        } else {
+            try {
+                final String mnemo = Mnemos.toText(arg);
+                    text.append(mnemo);
+
+            // @checkstyle IllegalCatch (1 line)
+            } catch (final Throwable ex) {
+                text.append(
+                    String.format(
+                        "[%s thrown %s]",
+                        arg.getClass().getName(),
+                        Mnemos.toText(ex)
+                    )
+                );
+            }
+        }
+        return text.toString();
+    }
+
+    /**
+     * Make a string out of an object.
+     * @param arg The argument
+     * @param trim Shall we trim long texts?
+     * @return Text representation of it
+     * @deprecated Use toText(Object,boolean,boolean) instead
+     */
+    @Deprecated
+    public static String toText(final Object arg, final boolean trim) {
+        return Mnemos.toText(arg, trim, false);
+    }
+
+    /**
+     * Make a string out of an object.
+     * @param arg The argument
+     * @param trim Shall we trim long texts?
+     * @return Text representation of it
+     * @deprecated Use toText() instead
+     */
+    @Deprecated
+    public static String toString(final Object arg, final boolean trim) {
+        return Mnemos.toText(arg, trim, false);
+    }
+
+    /**
+     * Make a string out of an object.
+     * @param arg The argument
+     * @return Text representation of it
+     */
+    private static String toText(final Object arg) {
+        String text;
+        if (arg.getClass().isArray()) {
+            if (arg instanceof Object[]) {
+                text = Mnemos.objectArrays((Object[]) arg);
+            } else {
+                text = Mnemos.primitiveArrays(arg);
+            }
+        } else {
+            final String origin = arg.toString();
+            if (arg instanceof String || origin.contains(" ")
+                || origin.isEmpty()) {
+                text = String.format("'%s'", origin);
+            } else {
+                text = origin;
+            }
+        }
+        return text;
+    }
+
+    /**
+     * Text representation of object arrays.
+     * @param arg Array to change into String.
+     * @return Array in String.
+     */
+    private static String objectArrays(final Object... arg) {
+        final StringBuilder bldr = new StringBuilder();
+        bldr.append('[');
+        for (final Object item : arg) {
+            if (bldr.length() > 1) {
+                bldr.append(Mnemos.COMMA);
+            }
+            bldr.append(Mnemos.toText(item, false, false));
+        }
+        return bldr.append(']').toString();
+    }
+
+    /**
+     * Text representation of primitive arrays.
+     * @param arg Array to change into String.
+     * @return Array in String.
+     */
+    private static String primitiveArrays(final Object arg) {
+        final String text;
+        if (arg instanceof char[]) {
+            text = Arrays.toString((char[]) arg);
+        } else if (arg instanceof byte[]) {
+            text = Arrays.toString((byte[]) arg);
+        } else if (arg instanceof short[]) {
+            text = Arrays.toString((short[]) arg);
+        } else if (arg instanceof int[]) {
+            text = Arrays.toString((int[]) arg);
+        } else if (arg instanceof long[]) {
+            text = Arrays.toString((long[]) arg);
+        } else if (arg instanceof float[]) {
+            text = Arrays.toString((float[]) arg);
+        } else if (arg instanceof double[]) {
+            text = Arrays.toString((double[]) arg);
+        } else if (arg instanceof boolean[]) {
+            text = Arrays.toString((boolean[]) arg);
+        } else {
+            text = "[unknown]";
+        }
+        return text;
+    }
+}

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/SizeCalculator.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/SizeCalculator.java
@@ -1,0 +1,7 @@
+package com.redhat.lightblue.util.stopwatch;
+
+public interface SizeCalculator<T> {
+
+    public int size(T object);
+
+}

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatch.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatch.java
@@ -1,0 +1,28 @@
+package com.redhat.lightblue.util.stopwatch;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use stopwatch to measure method execute time and log a warning if it's higher than threshold.
+ *
+ * @author mpatercz
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface StopWatch {
+
+    /**
+     *  -1 means use global value
+     */
+    int warnThresholdMS() default -1;
+
+    /**
+     * slf4j logger name
+     */
+    String loggerName() default "com.redhat.lightblue.crud.stopwatch";
+
+}

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatch.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatch.java
@@ -25,4 +25,12 @@ public @interface StopWatch {
      */
     String loggerName() default "com.redhat.lightblue.crud.stopwatch";
 
+    /**
+     * Class name used to calculate result size.
+     *
+     */
+    String sizeCalculatorClass() default "null";
+
+    int warnThresholdSizeB() default -1;
+
 }

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchAspect.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchAspect.java
@@ -91,48 +91,35 @@ public class StopWatchAspect {
     }
 
     private static Boolean enabled = null;
+    private static Integer globalWarnThresholdMS = null;
+    private static Integer globalWarnSizeThresholdB = null;
 
     private boolean enabled() {
         if (enabled == null) {
             enabled = Boolean.parseBoolean(System.getProperty(ENABLED_PROP, "false"));
+            globalWarnThresholdMS = Integer.parseInt(System.getProperty(GLOBAL_WARN_THRESHOLD_MS_PROP, "5000"));
+            globalWarnSizeThresholdB = Integer.parseInt(System.getProperty(GLOBAL_WARN_SIZE_THRESHOLD_B_PROP, "-1"));
+
+            logger.info("StopWatch initialized: enabled={}, globalWarnThresholdMS={}, globalWarnSizeThresholdB={}", enabled, globalWarnThresholdMS, globalWarnSizeThresholdB);
         }
         return enabled;
-    }
-
-    private static Integer globalWarnThresholdMS = null;
-
-    private int globalWarnThresholdMS() {
-        if (globalWarnThresholdMS == null) {
-            globalWarnThresholdMS = Integer.parseInt(System.getProperty(GLOBAL_WARN_THRESHOLD_MS_PROP, "5000"));
-        }
-        return globalWarnThresholdMS;
     }
 
     private int warnThresholdMS(ProceedingJoinPoint joinPoint) {
         int annotationWarnThresholdMS = getAnnotation(joinPoint).warnThresholdMS();
 
         if (annotationWarnThresholdMS < 0) {
-            return globalWarnThresholdMS();
+            return globalWarnThresholdMS;
         } else {
             return annotationWarnThresholdMS;
         }
     }
 
-    private static Integer globalWarnSizeThresholdB = null;
-
-    private int globalWarnSizeThresholdB() {
-        if (globalWarnSizeThresholdB == null) {
-            globalWarnSizeThresholdB = Integer.parseInt(System.getProperty(GLOBAL_WARN_SIZE_THRESHOLD_B_PROP, "-1"));
-        }
-        return globalWarnSizeThresholdB;
-    }
-
-
     private int warnSizeThresholdB(ProceedingJoinPoint joinPoint) {
         int annotationWarnSizeThresholdB = getAnnotation(joinPoint).warnThresholdSizeB();
 
         if (annotationWarnSizeThresholdB < 0) {
-            return globalWarnSizeThresholdB();
+            return globalWarnSizeThresholdB;
         } else {
             return annotationWarnSizeThresholdB;
         }

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchAspect.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchAspect.java
@@ -1,0 +1,102 @@
+package com.redhat.lightblue.util.stopwatch;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+
+/**
+ * Aspect with pointcut for all methods annotated with @StopWatch. Measures execution time and logs a warning if it's higher than threshold.
+ *
+ * @author mpatercz
+ *
+ */
+@Aspect
+public class StopWatchAspect {
+
+    static StopWatchLogger logger = new StopWatchLogger();
+
+    @Around("@annotation(StopWatch) && execution(* *(..))")
+    public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        if (!enabled()) {
+            return joinPoint.proceed();
+        }
+
+        String loggerName = getAnnotation(joinPoint).loggerName();
+        String className = joinPoint.getTarget().getClass().getSimpleName();
+
+        final long start = System.nanoTime();
+
+        try {
+            return joinPoint.proceed();
+        } catch (Throwable t) {
+            throw t;
+        } finally {
+            final long tookNano = System.nanoTime() - start;
+            final long tookMS = TimeUnit.MILLISECONDS.convert(tookNano, TimeUnit.NANOSECONDS);
+
+            if (tookMS >= warnThresholdMS(joinPoint)) {
+                logger.warn(loggerName, "Long call="+className+Mnemos.toText(joinPoint, false, false)+" executionTimeMS="+tookMS);
+            }
+
+            if (logger.isDebugEnabled(loggerName)) {
+                logger.debug(loggerName, "call="+className+Mnemos.toText(joinPoint, false, false)+" executionTimeMS="+tookMS);
+            }
+        }
+
+
+    }
+
+    public static final String ENABLED_PROP = "stopwatch.enabled", GLOBAL_WARN_THRESHOLD_MS_PROP = "stopwatch.globalWarnThresholdMS";
+
+    private StopWatch getAnnotation(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        return method.getAnnotation(StopWatch.class);
+    }
+
+    private static Boolean enabled = null;
+
+    private boolean enabled() {
+        if (enabled == null) {
+            enabled = Boolean.parseBoolean(System.getProperty(ENABLED_PROP, "false"));
+        }
+        return enabled;
+    }
+
+    private static Integer globalWarnThresholdMS = null;
+
+    private int globalWarnThresholdMS() {
+        if (globalWarnThresholdMS == null) {
+            globalWarnThresholdMS = Integer.parseInt(System.getProperty(GLOBAL_WARN_THRESHOLD_MS_PROP, "5000"));
+        }
+        return globalWarnThresholdMS;
+    }
+
+    private int warnThresholdMS(ProceedingJoinPoint joinPoint) {
+        int annotationWarnThresholdMS = getAnnotation(joinPoint).warnThresholdMS();
+
+        if (annotationWarnThresholdMS < 0) {
+            return globalWarnThresholdMS();
+        } else {
+            return annotationWarnThresholdMS;
+        }
+    }
+
+    // for testing only
+    static void clear() {
+        System.clearProperty(ENABLED_PROP);
+        System.clearProperty(GLOBAL_WARN_THRESHOLD_MS_PROP);
+
+        enabled = null;
+        globalWarnThresholdMS = null;
+    }
+
+
+
+}

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchAspect.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchAspect.java
@@ -26,13 +26,28 @@ public class StopWatchAspect {
             return joinPoint.proceed();
         }
 
-        String loggerName = getAnnotation(joinPoint).loggerName();
+        StopWatch stopWatch = getAnnotation(joinPoint);
+        String loggerName = stopWatch.loggerName();
         String className = joinPoint.getTarget().getClass().getSimpleName();
+
+        @SuppressWarnings("rawtypes")
+        SizeCalculator calc = getSizeCalculator(stopWatch);
 
         final long start = System.nanoTime();
 
         try {
-            return joinPoint.proceed();
+            Object returned = joinPoint.proceed();
+
+            // calculate result size and log a warning if exceeds threshold
+            if (returned != null && calc != null) {
+                @SuppressWarnings("unchecked")
+                int size = calc.size(returned);
+                if (warnSizeThresholdB(joinPoint) >= 0 && size >= warnSizeThresholdB(joinPoint)) {
+                    logger.warn(loggerName, "call="+className+Mnemos.toText(joinPoint, false, false)+" resultSize="+size);
+                }
+            }
+
+            return returned;
         } catch (Throwable t) {
             throw t;
         } finally {
@@ -40,24 +55,30 @@ public class StopWatchAspect {
             final long tookMS = TimeUnit.MILLISECONDS.convert(tookNano, TimeUnit.NANOSECONDS);
 
             if (tookMS >= warnThresholdMS(joinPoint)) {
-                logger.warn(loggerName, "Long call="+className+Mnemos.toText(joinPoint, false, false)+" executionTimeMS="+tookMS);
+                logger.warn(loggerName, "call="+className+Mnemos.toText(joinPoint, false, false)+" executionTimeMS="+tookMS);
             }
 
             if (logger.isDebugEnabled(loggerName)) {
                 logger.debug(loggerName, "call="+className+Mnemos.toText(joinPoint, false, false)+" executionTimeMS="+tookMS);
             }
         }
-
-
     }
 
-    public static final String ENABLED_PROP = "stopwatch.enabled", GLOBAL_WARN_THRESHOLD_MS_PROP = "stopwatch.globalWarnThresholdMS";
+    public static final String ENABLED_PROP = "stopwatch.enabled", GLOBAL_WARN_THRESHOLD_MS_PROP = "stopwatch.globalWarnThresholdMS",
+            GLOBAL_WARN_SIZE_THRESHOLD_B_PROP = "stopwatch.globalWarnSizeThresholdB";
 
     private StopWatch getAnnotation(ProceedingJoinPoint joinPoint) {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
 
         return method.getAnnotation(StopWatch.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private SizeCalculator getSizeCalculator(StopWatch stopWatch) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        String sizeCalculatorClass = stopWatch.sizeCalculatorClass();
+
+        return "null".equals(sizeCalculatorClass) ? null : (SizeCalculator)Class.forName(sizeCalculatorClass).asSubclass(SizeCalculator.class).newInstance();
     }
 
     private static Boolean enabled = null;
@@ -88,13 +109,35 @@ public class StopWatchAspect {
         }
     }
 
+    private static Integer globalWarnSizeThresholdB = null;
+
+    private int globalWarnSizeThresholdB() {
+        if (globalWarnSizeThresholdB == null) {
+            globalWarnSizeThresholdB = Integer.parseInt(System.getProperty(GLOBAL_WARN_SIZE_THRESHOLD_B_PROP, "-1"));
+        }
+        return globalWarnSizeThresholdB;
+    }
+
+
+    private int warnSizeThresholdB(ProceedingJoinPoint joinPoint) {
+        int annotationWarnSizeThresholdB = getAnnotation(joinPoint).warnThresholdSizeB();
+
+        if (annotationWarnSizeThresholdB < 0) {
+            return globalWarnSizeThresholdB();
+        } else {
+            return annotationWarnSizeThresholdB;
+        }
+    }
+
     // for testing only
     static void clear() {
         System.clearProperty(ENABLED_PROP);
         System.clearProperty(GLOBAL_WARN_THRESHOLD_MS_PROP);
+        System.clearProperty(GLOBAL_WARN_SIZE_THRESHOLD_B_PROP);
 
         enabled = null;
         globalWarnThresholdMS = null;
+        globalWarnSizeThresholdB = null;
     }
 
 

--- a/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchLogger.java
+++ b/util/src/main/java/com/redhat/lightblue/util/stopwatch/StopWatchLogger.java
@@ -1,0 +1,30 @@
+package com.redhat.lightblue.util.stopwatch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A logging wrapper to make unit tests easier.
+ *
+ * @author mpatercz
+ *
+ */
+public class StopWatchLogger {
+
+    private Logger getLogger(String loggerName) {
+        return LoggerFactory.getLogger(loggerName);
+    }
+
+    public void warn(String loggerName, String message) {
+        getLogger(loggerName).warn(message);
+    }
+
+    public void debug(String loggerName, String message) {
+        getLogger(loggerName).debug(message);
+    }
+
+    public boolean isDebugEnabled(String loggerName) {
+        return getLogger(loggerName).isDebugEnabled();
+    }
+
+}

--- a/util/src/test/java/com/redhat/lightblue/util/JsonUtilsTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/JsonUtilsTest.java
@@ -157,4 +157,9 @@ public class JsonUtilsTest {
 
         Assert.assertEquals(378, JsonUtils.size(node));
     }
+
+    @Test
+    public void testSizeForNullNode() throws Exception {
+        Assert.assertEquals(0, JsonUtils.size(null));
+    }
 }

--- a/util/src/test/java/com/redhat/lightblue/util/JsonUtilsTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/JsonUtilsTest.java
@@ -150,4 +150,11 @@ public class JsonUtilsTest {
         Assert.assertEquals("value1",node.get("v1").asText());
         Assert.assertEquals(1,node.get("o").get("a").get(0).asInt());
     }
+
+    @Test
+    public void testSize() throws Exception {
+        JsonNode node=JsonUtils.json(getClass().getResourceAsStream("/JsonNodeDocRelativeTest-complexarray.json"));
+
+        Assert.assertEquals(378, JsonUtils.size(node));
+    }
 }

--- a/util/src/test/java/com/redhat/lightblue/util/stopwatch/StopWatchTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/stopwatch/StopWatchTest.java
@@ -76,7 +76,7 @@ public class StopWatchTest {
     @Before
     public void before() {
         logger = new MockStopWatchLogger();
-        StopWatchAspect.logger = logger;
+        StopWatchAspect.stopWatchLogger = logger;
         StopWatchAspect.clear();
     }
 

--- a/util/src/test/java/com/redhat/lightblue/util/stopwatch/StopWatchTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/stopwatch/StopWatchTest.java
@@ -1,0 +1,124 @@
+package com.redhat.lightblue.util.stopwatch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class StopWatchTest {
+
+    class StopWatched {
+
+        @StopWatch(loggerName="logger", warnThresholdMS=100)
+        public void watchedMethodExplicitThreshold(int executionTimeMS) {
+            try {
+                Thread.sleep(executionTimeMS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        @StopWatch(loggerName="logger")
+        public void watchedMethod(int executionTimeMS) {
+            try {
+                Thread.sleep(executionTimeMS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+    class MockStopWatchLogger extends StopWatchLogger {
+
+        List<String> logEntries = new ArrayList<>();
+
+        @Override
+        public void warn(String loggerName, String message) {
+            logEntries.add("WARN "+loggerName+": "+message);
+        }
+
+        @Override
+        public void debug(String loggerName, String message) {
+            logEntries.add("DEBUG "+loggerName+": "+message);
+        }
+
+        @Override
+        public boolean isDebugEnabled(String loggerName) {
+            return false;
+        }
+
+    }
+
+    MockStopWatchLogger logger;
+
+    @Before
+    public void before() {
+        logger = new MockStopWatchLogger();
+        StopWatchAspect.logger = logger;
+        StopWatchAspect.clear();
+    }
+
+    @Test
+    public void testExplicitExecutionTimeThreshold() {
+        System.setProperty("stopwatch.enabled", "true");
+
+        StopWatched w = new StopWatched();
+
+        w.watchedMethodExplicitThreshold(50);
+
+        Assert.assertEquals(0,logger.logEntries.size());
+
+        w.watchedMethodExplicitThreshold(150);
+
+        Assert.assertEquals(1,logger.logEntries.size());
+        Assert.assertTrue(logger.logEntries.get(0).startsWith("WARN logger: Long call=StopWatched#watchedMethodExplicitThreshold(150) executionTimeMS=1"));
+    }
+
+    @Test
+    public void testGlobalExecutionTimeThreshold() {
+        System.setProperty("stopwatch.enabled", "true");
+        System.setProperty("stopwatch.globalWarnThresholdMS", "100");
+
+        StopWatched w = new StopWatched();
+
+        w.watchedMethod(50);
+
+        Assert.assertEquals(0,logger.logEntries.size());
+
+        w.watchedMethod(150);
+
+        Assert.assertEquals(1,logger.logEntries.size());
+        Assert.assertTrue(logger.logEntries.get(0).startsWith("WARN logger: Long call=StopWatched#watchedMethod(150) executionTimeMS=1"));
+    }
+
+    @Test
+    public void testExplicitThresholdTakesPrecedenseOverGlobal() {
+        System.setProperty("stopwatch.enabled", "true");
+        System.setProperty("stopwatch.globalWarnThresholdMS", "5");
+
+        StopWatched w = new StopWatched();
+
+        w.watchedMethodExplicitThreshold(50);
+
+        Assert.assertEquals(0,logger.logEntries.size());
+
+        w.watchedMethodExplicitThreshold(150);
+
+        Assert.assertEquals(1,logger.logEntries.size());
+        Assert.assertTrue(logger.logEntries.get(0).startsWith("WARN logger: Long call=StopWatched#watchedMethodExplicitThreshold(150) executionTimeMS=1"));
+    }
+
+    @Test
+    public void testNothingIsLoggedWhenFeatureDisabled() {
+        StopWatched w = new StopWatched();
+
+        w.watchedMethodExplicitThreshold(150);
+
+        Assert.assertEquals(0,logger.logEntries.size());
+    }
+
+}


### PR DESCRIPTION
A very simple and unintrusive logging of crud operations, in lieu of proper profiling instrumentation. Main purpose is to be able to see inside bulk operations, but can be easily added to other lightblue modules and methods.

Warning: StopWatches on mediator operations will log entire requests, including secrets. For that reason this feature is disabled by default. It can be controlled using system properties (-Dstopwatch.enabled=true to start logging, -Dstopwatch.globalWarnThresholdMS=10000 to change global threshold).