### PR TITLE
Result set size cap to prevent OoM errors

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/CrudConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/CrudConfiguration.java
@@ -49,6 +49,8 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
     private boolean validateRequests = false;
     private int bulkParallelExecutions = 3;
     private int memoryIndexThreshold = 16;
+    private int maxResultSetSizeB = 50 * 1024 * 1024; // 50 MB
+    private int warnResultSetSizeB = 10 * 1024 * 1024; // 10 MB
 
     public boolean isValidateRequests() {
         return validateRequests;
@@ -135,6 +137,16 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
             if (x != null) {
                 memoryIndexThreshold = x.intValue();
             }
+
+            x = node.get("maxResultSetSizeB");
+            if (x != null) {
+                maxResultSetSizeB = x.intValue();
+            }
+
+            x = node.get("warnResultSetSizeB");
+            if (x != null) {
+                warnResultSetSizeB = x.intValue();
+            }
         }
     }
 
@@ -144,5 +156,21 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
 
     void setMemoryIndexThreshold(int memoryIndexThreshold) {
         this.memoryIndexThreshold = memoryIndexThreshold;
+    }
+
+    public int getMaxResultSetSizeB() {
+        return maxResultSetSizeB;
+    }
+
+    public void setMaxResultSetSizeB(int maxResultSetSizeB) {
+        this.maxResultSetSizeB = maxResultSetSizeB;
+    }
+
+    public int getWarnResultSetSizeB() {
+        return warnResultSetSizeB;
+    }
+
+    public void setWarnResultSetSizeB(int warnResultSetSizeB) {
+        this.warnResultSetSizeB = warnResultSetSizeB;
     }
 }

--- a/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
+++ b/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
@@ -161,6 +161,8 @@ public final class LightblueFactory implements Serializable {
             f.setBulkParallelExecutions(crudConfiguration.getBulkParallelExecutions());
             f.setMemoryIndexThreshold(crudConfiguration.getMemoryIndexThreshold());
             f.addFieldConstraintValidators(new DefaultFieldConstraintValidators());
+            f.setMaxResultSetSizeB(crudConfiguration.getMaxResultSetSizeB());
+            f.setWarnResultSetSizeB(crudConfiguration.getWarnResultSetSizeB());
 
             // Add default interceptors
             new UIDInterceptor().register(f.getInterceptors());
@@ -174,6 +176,8 @@ public final class LightblueFactory implements Serializable {
             }
             // Make sure we assign factory after it is initialized. (factory is volatile, there's a memory barrier here)
             factory = f;
+
+            LOGGER.info("Initialized factory: {}", factory);
         }
     }
 

--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -49,7 +49,7 @@ public class Response extends BaseResponse  {
     private Request forRequest;
     private boolean warnThresholdBreached = false;
 
-    // TODO: Response has no access to CrudConstants
+    // Response has no access to CrudConstants
     public static final String ERR_RESULT_SIZE_TOO_LARGE = "crud:ResultSizeTooLarge";
 
 

--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -18,25 +18,38 @@
  */
 package com.redhat.lightblue;
 
+import java.util.Iterator;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import com.redhat.lightblue.util.Error;
+import com.redhat.lightblue.util.JsonUtils;
 
 /**
  * Response information from mediator APIs
  */
 public class Response extends BaseResponse  {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Response.class);
+
     private static final String PROPERTY_PROCESSED = "processed";
     private static final String PROPERTY_RESULT_METADATA = "resultMetadata";
 
     private JsonNode entityData;
     private List<ResultMetadata> resultMetadata;
+
+    private int responseDataSizeB = 0;
+    private int maxResultSetSizeB = -1, warnResultSetSizeB = -1;
+    private Request forRequest;
+
+    // TODO: Response has no access to CrudConstants
+    public static final String ERR_RESULT_SIZE_TOO_LARGE = "crud:ResultSizeTooLarge";
 
 
     /**
@@ -59,6 +72,24 @@ public class Response extends BaseResponse  {
 
     public Response(BaseResponse r) {
         super(r);
+    }
+
+    public void ensureResponseSizeNotTooLarge(int maxResultSetSizeB, int warnResultSetSizeB, Request forRequest) {
+        this.forRequest = forRequest;
+        this.maxResultSetSizeB = maxResultSetSizeB;
+        this.warnResultSetSizeB = warnResultSetSizeB;
+    }
+
+    public boolean isEnsureResposneSizeNotTooLarge() {
+        return maxResultSetSizeB > 0;
+    }
+
+    public boolean isWarnResponseSizeLarge() {
+        return warnResultSetSizeB > 0;
+    }
+
+    public boolean isCheckResponseSize() {
+        return isEnsureResposneSizeNotTooLarge() || isWarnResponseSizeLarge();
     }
 
     /**
@@ -87,9 +118,12 @@ public class Response extends BaseResponse  {
      */
     public void addEntityData(JsonNode doc) {
         if(doc!=null) {
+
+            enforceResponseSizeLimits(doc);
+
             if(entityData==null) {
                 entityData=JsonNodeFactory.instance.arrayNode();
-            } 
+            }
             if(doc instanceof ArrayNode) {
                 for(Iterator<JsonNode> itr=doc.elements();itr.hasNext();) {
                     ((ArrayNode)entityData).add(itr.next());
@@ -98,6 +132,37 @@ public class Response extends BaseResponse  {
                 ((ArrayNode)entityData).add(doc);
             }
         }
+    }
+
+    /**
+     * Ensures that the response is not larger than maxResultSetSizeB to protect Lightblue from running out of memory when building large result sets.
+     *
+     * This method is used to checks only the data part of the response. TODO: check dataErrors as well, as they include entire docs.
+     *
+     * @param entityDataJson json being added to the response
+     */
+    private void enforceResponseSizeLimits(JsonNode entityDataJson) {
+
+        if (isCheckResponseSize()) {
+            responseDataSizeB += JsonUtils.size(entityDataJson);
+
+            // TODO: could account for copies made for hooks here
+            // better do https://github.com/lightblue-platform/lightblue-core/issues/802 instead
+        }
+
+        if (isCheckResponseSize()&& responseDataSizeB >= maxResultSetSizeB) {
+            LOGGER.error(ERR_RESULT_SIZE_TOO_LARGE + ": request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
+
+            // empty data
+            // returning incomplete result set could be useful, but also confusing and thus dangerous
+            // the counts - matchCount, modifiedCount - are unmodified
+            setEntityData(JsonNodeFactory.instance.arrayNode());
+
+            throw Error.get(ERR_RESULT_SIZE_TOO_LARGE, responseDataSizeB+"B > "+maxResultSetSizeB+"B");
+        } else if (isWarnResponseSizeLarge() && responseDataSizeB >= warnResultSetSizeB) {
+            LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
+        }
+
     }
 
     /**
@@ -129,5 +194,9 @@ public class Response extends BaseResponse  {
             node.set(PROPERTY_RESULT_METADATA,arr);
         }
         return node;
+    }
+
+    public int getResponseDataSizeB() {
+        return responseDataSizeB;
     }
 }

--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -150,7 +150,7 @@ public class Response extends BaseResponse  {
             // better do https://github.com/lightblue-platform/lightblue-core/issues/802 instead
         }
 
-        if (isCheckResponseSize()&& responseDataSizeB >= maxResultSetSizeB) {
+        if (isEnsureResposneSizeNotTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
             LOGGER.error(ERR_RESULT_SIZE_TOO_LARGE + ": request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
 
             // empty data

--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -80,7 +80,7 @@ public class Response extends BaseResponse  {
      *
      * @param maxResultSetSizeB error when this threshold is breached
      * @param warnResultSetSizeB log a warning when this threshold is breached
-     * @param forRequest request which resulted in this resposne, for logging purposes
+     * @param forRequest request which resulted in this response, for logging purposes
      */
     public void setResultSizeThresholds(int maxResultSetSizeB, int warnResultSetSizeB, Request forRequest) {
         this.forRequest = forRequest;
@@ -88,7 +88,7 @@ public class Response extends BaseResponse  {
         this.warnResultSetSizeB = warnResultSetSizeB;
     }
 
-    public boolean isErrorOnResposneSizeTooLarge() {
+    public boolean isErrorOnResponseSizeTooLarge() {
         return maxResultSetSizeB > 0;
     }
 
@@ -97,7 +97,7 @@ public class Response extends BaseResponse  {
     }
 
     public boolean isCheckResponseSize() {
-        return isErrorOnResposneSizeTooLarge() || isWarnOnResponseSizeLarge();
+        return isErrorOnResponseSizeTooLarge() || isWarnOnResponseSizeLarge();
     }
 
     /**
@@ -155,7 +155,7 @@ public class Response extends BaseResponse  {
             responseDataSizeB += JsonUtils.size(entityDataJson);
         }
 
-        if (isErrorOnResposneSizeTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
+        if (isErrorOnResponseSizeTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
             // empty data
             // returning incomplete result set could be useful, but also confusing and thus dangerous
             // the counts - matchCount, modifiedCount - are unmodified

--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -82,7 +82,7 @@ public class Response extends BaseResponse  {
      * @param warnResultSetSizeB log a warning when this threshold is breached
      * @param forRequest request which resulted in this resposne, for logging purposes
      */
-    public void ensureResponseSizeNotTooLarge(int maxResultSetSizeB, int warnResultSetSizeB, Request forRequest) {
+    public void setResultSizeThresholds(int maxResultSetSizeB, int warnResultSetSizeB, Request forRequest) {
         this.forRequest = forRequest;
         this.maxResultSetSizeB = maxResultSetSizeB;
         this.warnResultSetSizeB = warnResultSetSizeB;

--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -152,8 +152,6 @@ public class Response extends BaseResponse  {
         }
 
         if (isEnsureResposneSizeNotTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
-            LOGGER.error(ERR_RESULT_SIZE_TOO_LARGE + ": request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
-
             // empty data
             // returning incomplete result set could be useful, but also confusing and thus dangerous
             // the counts - matchCount, modifiedCount - are unmodified

--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -47,6 +47,7 @@ public class Response extends BaseResponse  {
     private int responseDataSizeB = 0;
     private int maxResultSetSizeB = -1, warnResultSetSizeB = -1;
     private Request forRequest;
+    private boolean warnThresholdBreached = false;
 
     // TODO: Response has no access to CrudConstants
     public static final String ERR_RESULT_SIZE_TOO_LARGE = "crud:ResultSizeTooLarge";
@@ -159,8 +160,9 @@ public class Response extends BaseResponse  {
             setEntityData(JsonNodeFactory.instance.arrayNode());
 
             throw Error.get(ERR_RESULT_SIZE_TOO_LARGE, responseDataSizeB+"B > "+maxResultSetSizeB+"B");
-        } else if (isWarnResponseSizeLarge() && responseDataSizeB >= warnResultSetSizeB) {
+        } else if (isWarnResponseSizeLarge() && !warnThresholdBreached && responseDataSizeB >= warnResultSetSizeB) {
             LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
+            warnThresholdBreached = true;
         }
 
     }

--- a/crud/src/main/java/com/redhat/lightblue/crud/CrudConstants.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/CrudConstants.java
@@ -78,6 +78,8 @@ public final class CrudConstants {
 
     public static final String ERR_DATASOURCE_UNKNOWN = "crud:DataSourceUnknown";
 
+    public static final String ERR_RESULT_SIZE_TOO_LARGE = "crud:ResultSizeTooLarge";
+
     private CrudConstants() {
 
     }

--- a/crud/src/main/java/com/redhat/lightblue/crud/CrudConstants.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/CrudConstants.java
@@ -78,8 +78,6 @@ public final class CrudConstants {
 
     public static final String ERR_DATASOURCE_UNKNOWN = "crud:DataSourceUnknown";
 
-    public static final String ERR_RESULT_SIZE_TOO_LARGE = "crud:ResultSizeTooLarge";
-
     private CrudConstants() {
 
     }

--- a/crud/src/main/java/com/redhat/lightblue/crud/Factory.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/Factory.java
@@ -62,6 +62,8 @@ public class Factory implements Serializable {
     private JsonNodeFactory nodeFactory;
     private int bulkParallelExecutions = 3;
     private int memoryIndexThreshold = 16;
+    private int maxResultSetSizeB;
+    private int warnResultSetSizeB;
 
     /**
      * Adds a field constraint validator
@@ -226,5 +228,30 @@ public class Factory implements Serializable {
 
     public void setMemoryIndexThreshold(int memoryIndexThreshold) {
         this.memoryIndexThreshold = memoryIndexThreshold;
+    }
+
+    public int getMaxResultSetSizeB() {
+        return maxResultSetSizeB;
+    }
+
+    public void setMaxResultSetSizeB(int maxResultSetSizeB) {
+        this.maxResultSetSizeB = maxResultSetSizeB;
+    }
+
+    public int getWarnResultSetSizeB() {
+        return warnResultSetSizeB;
+    }
+
+    public void setWarnResultSetSizeB(int warnResultSetSizeB) {
+        this.warnResultSetSizeB = warnResultSetSizeB;
+    }
+
+    @Override
+    public String toString() {
+        return "Factory [fieldConstraintValidatorRegistry=" + fieldConstraintValidatorRegistry + ", entityConstraintValidatorRegistry="
+                + entityConstraintValidatorRegistry + ", crudControllers=" + crudControllers + ", hookResolver=" + hookResolver + ", interceptors="
+                + interceptors + ", generators=" + generators + ", nodeFactory=" + nodeFactory + ", bulkParallelExecutions=" + bulkParallelExecutions
+                + ", memoryIndexThreshold=" + memoryIndexThreshold + ", maxResultSetSizeB=" + maxResultSetSizeB + ", warnResultSetSizeB=" + warnResultSetSizeB
+                + "]";
     }
 }

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -81,7 +81,7 @@ public class HookManager {
      * @param warnResultSetSizeB log a warning when this threshold is breached
      * @param forRequest request which resulted in this resposne, for logging purposes
      */
-    public void ensureQueuedHooksSizeNotTooLarge(int maxQueuedHooksSizeB, int warnQueuedHooksSizeB, Request forRequest) {
+    public void setQueuedHooksSizeThresholds(int maxQueuedHooksSizeB, int warnQueuedHooksSizeB, Request forRequest) {
         this.forRequest = forRequest;
         this.maxQueuedHooksSizeB = maxQueuedHooksSizeB;
         this.warnQueuedHooksSizeB = warnQueuedHooksSizeB;

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -229,6 +229,8 @@ public class HookManager {
         queuedHooks.clear();
 
         queuedHooksSizeB = 0;
+        warnQueuedHooksSizeB = -1;
+        maxQueuedHooksSizeB = -1;
         forRequest = null;
         warnThresholdBreached = false;
     }

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -74,22 +74,29 @@ public class HookManager {
         return queuedHooksSizeB;
     }
 
+    /**
+     * Threshold is expressed in bytes. This is just an approximation, see @{link {@link JsonUtils#size(JsonNode)} for details.
+     *
+     * @param maxResultSetSizeB error when this threshold is breached
+     * @param warnResultSetSizeB log a warning when this threshold is breached
+     * @param forRequest request which resulted in this resposne, for logging purposes
+     */
     public void ensureQueuedHooksSizeNotTooLarge(int maxQueuedHooksSizeB, int warnQueuedHooksSizeB, Request forRequest) {
         this.forRequest = forRequest;
         this.maxQueuedHooksSizeB = maxQueuedHooksSizeB;
         this.warnQueuedHooksSizeB = warnQueuedHooksSizeB;
     }
 
-    public boolean isEnsureQueueSizeNotTooLarge() {
+    public boolean isErrorOnQueueSizeTooLarge() {
         return maxQueuedHooksSizeB > 0;
     }
 
-    public boolean isWarnQueueSizeLarge() {
+    public boolean isWarnOnQueueSizeLarge() {
         return warnQueuedHooksSizeB > 0;
     }
 
     public boolean isCheckQueueSize() {
-        return isEnsureQueueSizeNotTooLarge() || isWarnQueueSizeLarge();
+        return isErrorOnQueueSizeTooLarge() || isWarnOnQueueSizeLarge();
     }
 
     private JsonNode enforceQueueSizeLimits(JsonNode jsonNode) {
@@ -98,11 +105,11 @@ public class HookManager {
             queuedHooksSizeB += JsonUtils.size(jsonNode);
         }
 
-        if (isEnsureQueueSizeNotTooLarge() && queuedHooksSizeB >= maxQueuedHooksSizeB) {
+        if (isErrorOnQueueSizeTooLarge() && queuedHooksSizeB >= maxQueuedHooksSizeB) {
 
 
             throw Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, queuedHooksSizeB+"B > "+maxQueuedHooksSizeB+"B");
-        } else if (isWarnQueueSizeLarge() && !warnThresholdBreached && queuedHooksSizeB >= warnQueuedHooksSizeB) {
+        } else if (isWarnOnQueueSizeLarge() && !warnThresholdBreached && queuedHooksSizeB >= warnQueuedHooksSizeB) {
             LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, queuedHooks);
             warnThresholdBreached = true;
         }

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -79,7 +79,7 @@ public class HookManager {
      *
      * @param maxResultSetSizeB error when this threshold is breached
      * @param warnResultSetSizeB log a warning when this threshold is breached
-     * @param forRequest request which resulted in this resposne, for logging purposes
+     * @param forRequest request which resulted in this response, for logging purposes
      */
     public void setQueuedHooksSizeThresholds(int maxQueuedHooksSizeB, int warnQueuedHooksSizeB, Request forRequest) {
         this.forRequest = forRequest;

--- a/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
@@ -36,7 +36,7 @@ public class BulkExecutionContext {
      * @param warnResultSetSizeB log a warning when this threshold is breached
      * @param forRequest request which resulted in this resposne, for logging purposes
      */
-    public void ensureResponseSizeNotTooLarge(int maxResultSetSizeB, int warnResultSetSizeB, BulkRequest forRequest) {
+    public void setResultSizeThresholds(int maxResultSetSizeB, int warnResultSetSizeB, BulkRequest forRequest) {
         this.forRequest = forRequest;
         this.maxResultSetSizeB = maxResultSetSizeB;
         this.warnResultSetSizeB = warnResultSetSizeB;

--- a/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
@@ -1,0 +1,73 @@
+package com.redhat.lightblue.mediator;
+
+import java.util.concurrent.Future;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.crud.BulkRequest;
+import com.redhat.lightblue.util.Error;
+
+public class BulkExecutionContext {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BulkExecutionContext.class);
+
+    final Future<Response>[] futures;
+    private Response[] responses;
+
+    private int responseDataSizeB = 0;
+    private int maxResultSetSizeB = -1, warnResultSetSizeB = -1;
+    private BulkRequest forRequest;
+
+    public BulkExecutionContext(int size) {
+        futures = new Future[size];
+        responses = new Response[size];
+    }
+
+    public void ensureResponseSizeNotTooLarge(int maxResultSetSizeB, int warnResultSetSizeB, BulkRequest forRequest) {
+        this.forRequest = forRequest;
+        this.maxResultSetSizeB = maxResultSetSizeB;
+        this.warnResultSetSizeB = warnResultSetSizeB;
+    }
+
+    public boolean isEnsureResposneSizeNotTooLarge() {
+        return maxResultSetSizeB > 0;
+    }
+
+    public boolean isWarnResponseSizeLarge() {
+        return warnResultSetSizeB > 0;
+    }
+
+    public boolean isCheckResponseSize() {
+        return isEnsureResposneSizeNotTooLarge() || isWarnResponseSizeLarge();
+    }
+
+    private void enforceResponseSizeLimits(Response response) {
+        if (isCheckResponseSize()) {
+            responseDataSizeB += response.getResponseDataSizeB();
+        }
+
+        if (isEnsureResposneSizeNotTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
+            LOGGER.error(Response.ERR_RESULT_SIZE_TOO_LARGE + ": request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
+
+            // remove data
+            response.setEntityData(JsonNodeFactory.instance.arrayNode());
+            response.getErrors().add(Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, responseDataSizeB+"B > "+maxResultSetSizeB+"B"));
+        } else if (isWarnResponseSizeLarge() && responseDataSizeB >= warnResultSetSizeB) {
+            LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
+        }
+
+    }
+
+    public void setResponseAt(int index, Response response) {
+        enforceResponseSizeLimits(response);
+
+        responses[index] = response;
+    }
+
+    public Response[] getResponses() {
+        return responses;
+    }
+}

--- a/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
@@ -34,7 +34,7 @@ public class BulkExecutionContext {
      *
      * @param maxResultSetSizeB error when this threshold is breached
      * @param warnResultSetSizeB log a warning when this threshold is breached
-     * @param forRequest request which resulted in this resposne, for logging purposes
+     * @param forRequest request which resulted in this response, for logging purposes
      */
     public void setResultSizeThresholds(int maxResultSetSizeB, int warnResultSetSizeB, BulkRequest forRequest) {
         this.forRequest = forRequest;
@@ -42,7 +42,7 @@ public class BulkExecutionContext {
         this.warnResultSetSizeB = warnResultSetSizeB;
     }
 
-    public boolean isErrorOnResposneSizeTooLarge() {
+    public boolean isErrorOnResponseSizeTooLarge() {
         return maxResultSetSizeB > 0;
     }
 
@@ -51,7 +51,7 @@ public class BulkExecutionContext {
     }
 
     public boolean isCheckResponseSize() {
-        return isErrorOnResposneSizeTooLarge() || isWarnOnResponseSizeLarge();
+        return isErrorOnResponseSizeTooLarge() || isWarnOnResponseSizeLarge();
     }
 
     private void enforceResponseSizeLimits(Response response) {
@@ -59,7 +59,7 @@ public class BulkExecutionContext {
             responseDataSizeB += response.getResponseDataSizeB();
         }
 
-        if (isErrorOnResposneSizeTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
+        if (isErrorOnResponseSizeTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
             // remove data
             response.setEntityData(JsonNodeFactory.instance.arrayNode());
             response.getErrors().add(Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, responseDataSizeB+"B > "+maxResultSetSizeB+"B"));

--- a/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
@@ -61,6 +61,13 @@ public class BulkExecutionContext {
 
     }
 
+    /**
+     * This method is not thread safe (specifically, managing responseDataSizeB isn't). That's ok, because a single thread gathers
+     * responses from requests processed in parallel and adds them to {@link BulkExecutionContext}.
+     *
+     * @param index
+     * @param response
+     */
     public void setResponseAt(int index, Response response) {
         enforceResponseSizeLimits(response);
 

--- a/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
@@ -20,6 +20,7 @@ public class BulkExecutionContext {
     private int responseDataSizeB = 0;
     private int maxResultSetSizeB = -1, warnResultSetSizeB = -1;
     private BulkRequest forRequest;
+    private boolean warnThresholdBreached = false;
 
     public BulkExecutionContext(int size) {
         futures = new Future[size];
@@ -55,8 +56,9 @@ public class BulkExecutionContext {
             // remove data
             response.setEntityData(JsonNodeFactory.instance.arrayNode());
             response.getErrors().add(Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, responseDataSizeB+"B > "+maxResultSetSizeB+"B"));
-        } else if (isWarnResponseSizeLarge() && responseDataSizeB >= warnResultSetSizeB) {
+        } else if (isWarnResponseSizeLarge() && !warnThresholdBreached && responseDataSizeB >= warnResultSetSizeB) {
             LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
+            warnThresholdBreached = true;
         }
 
     }

--- a/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
@@ -51,8 +51,6 @@ public class BulkExecutionContext {
         }
 
         if (isEnsureResposneSizeNotTooLarge() && responseDataSizeB >= maxResultSetSizeB) {
-            LOGGER.error(Response.ERR_RESULT_SIZE_TOO_LARGE + ": request={}, responseDataSizeB={}", forRequest, responseDataSizeB);
-
             // remove data
             response.setEntityData(JsonNodeFactory.instance.arrayNode());
             response.getErrors().add(Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, responseDataSizeB+"B > "+maxResultSetSizeB+"B"));

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -492,17 +492,12 @@ public class Mediator {
                 DocumentStream<DocCtx> docStream=r.documentStream;
                 List<ResultMetadata> rmd=new ArrayList<>();
                 response.setEntityData(factory.getNodeFactory().arrayNode());
+                response.ensureResponseSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
 
-                int dataSizeB = 0;
                 for(;docStream.hasNext();) {
                     DocCtx doc=docStream.next();
                     if(!doc.hasErrors()) {
-
-                        JsonNode entityDataJson = doc.getOutputDocument().getRoot();
-
-                        dataSizeB = ensureResponseSizeNotTooLarge(entityDataJson, dataSizeB, req, response);
-
-                        response.addEntityData(entityDataJson);
+                        response.addEntityData(doc.getOutputDocument().getRoot());
                         rmd.add(doc.getResultMetadata());
                     } else {
                         DataError error=doc.getDataError();
@@ -529,40 +524,6 @@ public class Mediator {
         }
         
         return response;
-    }
-    
-    /**
-     * Ensures that the response is not larger than maxResultSetSizeB to protect Lightblue from running out of memory when building large result sets.
-     *
-     * This method checks only the data part of the response. This is enough for finds, because they do not generate large errors (write operations
-     * can include entire docs in the errors).
-     *
-     * @param entityDataJson A document being currently added to the response
-     * @param responseDataSizeB Current response data size
-     * @param request Request
-     * @param response Response
-     * @return responseDataSizeB + size(entityDataJson)
-     */
-    @StopWatch(loggerName = "stopwatch.com.redhat.lightblue.mediator.Mediator#ensureResponseSizeNotTooLarge", warnThresholdMS=10)
-    private int ensureResponseSizeNotTooLarge(JsonNode entityDataJson, int responseDataSizeB, Request request, Response response) {
-
-        if (factory.getMaxResultSetSizeB() > 0 || factory.getWarnResultSetSizeB() > 0) {
-            responseDataSizeB += JsonUtils.size(entityDataJson);
-        }
-
-        if (factory.getMaxResultSetSizeB() > 0 && responseDataSizeB >= factory.getMaxResultSetSizeB()) {
-            LOGGER.error(CrudConstants.ERR_RESULT_SIZE_TOO_LARGE + ": request={}, responseDataSizeB={}", request, responseDataSizeB);
-
-            // empty data
-            // returning incomplete result set could be useful, but also confusing and thus dangerous
-            response.setEntityData(factory.getNodeFactory().arrayNode());
-
-            throw Error.get(CrudConstants.ERR_RESULT_SIZE_TOO_LARGE, responseDataSizeB+"B > "+factory.getMaxResultSetSizeB()+"B");
-        } else if (factory.getWarnResultSetSizeB() > 0 && responseDataSizeB >= factory.getWarnResultSetSizeB()) {
-            LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", request, responseDataSizeB);
-        }
-
-        return responseDataSizeB;
     }
 
     public StreamingResponse findAndStream(FindRequest req) {
@@ -883,6 +844,9 @@ public class Mediator {
         DocumentStream<DocCtx> docStream=ctx.getDocumentStream();
         if(docStream!=null) {
             List<ResultMetadata> rmd=new ArrayList<>();
+
+            response.ensureResponseSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
+
             for(;docStream.hasNext();) {
                 DocCtx doc=docStream.next();
                 if(!doc.hasErrors()) {                

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -136,7 +136,7 @@ public class Mediator {
                 if (!ctx.hasErrors() && ctx.hasInputDocumentsWithoutErrors()) {
                     LOGGER.debug(CRUD_MSG_PREFIX, controller.getClass().getName());
                     CRUDInsertionResponse ir=controller.insert(ctx, req.getReturnFields());
-                    ctx.getHookManager().ensureQueuedHooksSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
+                    ctx.getHookManager().setQueuedHooksSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
                     ctx.getHookManager().queueMediatorHooks(ctx);
                     ctx.measure.begin("postProcessInsertedDocs");
                     response.setModifiedCount(ir.getNumInserted());
@@ -301,7 +301,7 @@ public class Mediator {
                         updateResponse.setNumMatched(0);
                     }
                 }
-                ctx.getHookManager().ensureQueuedHooksSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
+                ctx.getHookManager().setQueuedHooksSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
                 ctx.getHookManager().queueMediatorHooks(ctx);
                 ctx.measure.begin("postProcessUpdatedDocs");
                 LOGGER.debug("# Updated", updateResponse.getNumUpdated());                
@@ -373,7 +373,7 @@ public class Mediator {
                     }
                 }
 
-                ctx.getHookManager().ensureQueuedHooksSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
+                ctx.getHookManager().setQueuedHooksSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
                 ctx.getHookManager().queueMediatorHooks(ctx);
                 response.setModifiedCount(result == null ? 0 : result.getNumDeleted());
                 if (ctx.hasErrors()) {
@@ -493,7 +493,7 @@ public class Mediator {
                 DocumentStream<DocCtx> docStream=r.documentStream;
                 List<ResultMetadata> rmd=new ArrayList<>();
                 response.setEntityData(factory.getNodeFactory().arrayNode());
-                response.ensureResponseSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
+                response.setResultSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
 
                 for(;docStream.hasNext();) {
                     DocCtx doc=docStream.next();
@@ -696,7 +696,7 @@ public class Mediator {
             List<Request> requestList = requests.getEntries();
             int n = requestList.size();
             BulkExecutionContext ctx = new BulkExecutionContext(n);
-            ctx.ensureResponseSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), requests);
+            ctx.setResultSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), requests);
 
             for (int i = 0; i < n; i++) {
                 Request req = requestList.get(i);
@@ -840,7 +840,7 @@ public class Mediator {
             if (ctx.getHookManager().isHookQueueEmpty()) {
                 // ensure response size only if hooks didn't fire
                 // otherwise result stream is read during hook queuing and this is where those checks take place
-                response.ensureResponseSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
+                response.setResultSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
             }
 
             for(;docStream.hasNext();) {

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -838,7 +838,7 @@ public class Mediator {
             List<ResultMetadata> rmd=new ArrayList<>();
 
             if (ctx.getHookManager().isHookQueueEmpty()) {
-                // ensure response size not only if hooks didn't fire
+                // ensure response size only if hooks didn't fire
                 // otherwise result stream is read during hook queuing and this is where those checks take place
                 response.ensureResponseSizeNotTooLarge(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
             }

--- a/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
@@ -315,14 +315,14 @@ public class HookManagerTest extends AbstractJsonNodeTest {
                     JsonUtils.size(doc.getUpdatedDocument().getRoot()));  // post copy
         }
 
-        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB+10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB+10, 1, null);
 
         // queue hooks (process entire stream of results)
         hooks.queueHooks(ctx);
 
         Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
 
-        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB-10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null);
 
         try {
             hooks.queueHooks(ctx);
@@ -346,14 +346,14 @@ public class HookManagerTest extends AbstractJsonNodeTest {
                     JsonUtils.size(doc.getRoot())); // post copy
         }
 
-        hooks.ensureQueuedHooksSizeNotTooLarge(-1, 1, null);
+        hooks.setQueuedHooksSizeThresholds(-1, 1, null);
 
         // queue hooks (process entire stream of results)
         hooks.queueHooks(ctx);
 
         Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
 
-        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB-10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null);
 
         try {
             hooks.queueHooks(ctx);
@@ -377,14 +377,14 @@ public class HookManagerTest extends AbstractJsonNodeTest {
                     JsonUtils.size(doc.getRoot())); // pre copy
         }
 
-        hooks.ensureQueuedHooksSizeNotTooLarge(-1, 1, null);
+        hooks.setQueuedHooksSizeThresholds(-1, 1, null);
 
         // queue hooks (process entire stream of results)
         hooks.queueHooks(ctx);
 
         Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
 
-        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB-10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null);
 
         try {
             hooks.queueHooks(ctx);

--- a/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
@@ -58,7 +58,9 @@ import com.redhat.lightblue.crud.DocumentStream;
 
 import com.redhat.lightblue.util.test.AbstractJsonNodeTest;
 import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.JsonUtils;
 import com.redhat.lightblue.util.Path;
+import com.redhat.lightblue.util.Error;
 
 public class HookManagerTest extends AbstractJsonNodeTest {
 
@@ -296,6 +298,99 @@ public class HookManagerTest extends AbstractJsonNodeTest {
             Assert.assertNotNull(doc.getPreDoc());
             Assert.assertNotNull(doc.getPostDoc());
             Assert.assertEquals(CRUDOperation.UPDATE, doc.getCRUDOperation());
+        }
+    }
+
+    @Test
+    public void crudUpdateMaxHookQueueSizeTest() throws Exception {
+        HookManager hooks = new HookManager(resolver, nodeFactory);
+        TestOperationContext ctx = setupContext(CRUDOperation.UPDATE);
+
+        int expectedSizeB = 0;
+        int updateHookCount = 3;
+        for(DocCtx doc: ctx.getInputDocuments()) {
+            expectedSizeB += updateHookCount * (
+                    JsonUtils.size(doc.getOriginalDocument().getRoot()) + // original doc
+                    JsonUtils.size(doc.getOriginalDocument().getRoot()) + // pre copy
+                    JsonUtils.size(doc.getUpdatedDocument().getRoot()));  // post copy
+        }
+
+        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB+10, 1, null);
+
+        // queue hooks (process entire stream of results)
+        hooks.queueHooks(ctx);
+
+        Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
+
+        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB-10, 1, null);
+
+        try {
+            hooks.queueHooks(ctx);
+            Assert.fail("Hook queue exceeds limit, expecting exception");
+        } catch (Error e) {
+            Assert.assertEquals("crud:ResultSizeTooLarge", e.getErrorCode());
+        }
+    }
+
+    @Test
+    public void crudInsertMaxHookQueueSizeTest() throws Exception {
+        HookManager hooks = new HookManager(resolver, nodeFactory);
+        TestOperationContext ctx = setupContext(CRUDOperation.INSERT);
+
+        int expectedSizeB = 0;
+        int insertHookCount = 1;
+
+        for(DocCtx doc: ctx.getInputDocuments()) {
+            expectedSizeB += insertHookCount * (
+                    JsonUtils.size(doc.getRoot()) + // original doc
+                    JsonUtils.size(doc.getRoot())); // post copy
+        }
+
+        hooks.ensureQueuedHooksSizeNotTooLarge(-1, 1, null);
+
+        // queue hooks (process entire stream of results)
+        hooks.queueHooks(ctx);
+
+        Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
+
+        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB-10, 1, null);
+
+        try {
+            hooks.queueHooks(ctx);
+            Assert.fail("Hook queue exceeds limit, expecting exception");
+        } catch (Error e) {
+            Assert.assertEquals("crud:ResultSizeTooLarge", e.getErrorCode());
+        }
+    }
+
+    @Test
+    public void crudDeleteMaxHookQueueSizeTest() throws Exception {
+        HookManager hooks = new HookManager(resolver, nodeFactory);
+        TestOperationContext ctx = setupContext(CRUDOperation.DELETE);
+
+        int expectedSizeB = 0;
+        int deleteHookCount = 1;
+
+        for(DocCtx doc: ctx.getInputDocuments()) {
+            expectedSizeB += deleteHookCount * (
+                    JsonUtils.size(doc.getRoot()) + // original doc
+                    JsonUtils.size(doc.getRoot())); // pre copy
+        }
+
+        hooks.ensureQueuedHooksSizeNotTooLarge(-1, 1, null);
+
+        // queue hooks (process entire stream of results)
+        hooks.queueHooks(ctx);
+
+        Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
+
+        hooks.ensureQueuedHooksSizeNotTooLarge(expectedSizeB-10, 1, null);
+
+        try {
+            hooks.queueHooks(ctx);
+            Assert.fail("Hook queue exceeds limit, expecting exception");
+        } catch (Error e) {
+            Assert.assertEquals("crud:ResultSizeTooLarge", e.getErrorCode());
         }
     }
 

--- a/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
@@ -189,8 +189,6 @@ public class BulkTest extends AbstractMediatorTest {
         Assert.assertEquals("The second request should error, as it exceeds the response size threshold", 1, responseFind.getErrors().size());
         Assert.assertEquals(Response.ERR_RESULT_SIZE_TOO_LARGE, responseFind.getErrors().get(0).getErrorCode());
         Assert.assertEquals("The second request contains no data", 0, responseFind.getEntityData().size());
-
-        // TODO: don't print the error twice (Error.get also does it)
     }
 
     @Test

--- a/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
@@ -190,7 +190,6 @@ public class BulkTest extends AbstractMediatorTest {
         Assert.assertEquals(Response.ERR_RESULT_SIZE_TOO_LARGE, responseFind.getErrors().get(0).getErrorCode());
         Assert.assertEquals("The second request contains no data", 0, responseFind.getEntityData().size());
 
-        // TODO: make those meta fields in response transient
         // TODO: don't print the error twice (Error.get also does it)
     }
 

--- a/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
@@ -18,31 +18,36 @@
  */
 package com.redhat.lightblue.mediator;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.lightblue.EntityVersion;
 import com.redhat.lightblue.OperationStatus;
 import com.redhat.lightblue.Response;
+import com.redhat.lightblue.ResultMetadata;
 import com.redhat.lightblue.crud.BulkRequest;
 import com.redhat.lightblue.crud.BulkResponse;
-import com.redhat.lightblue.crud.CrudConstants;
-import com.redhat.lightblue.crud.Factory;
+import com.redhat.lightblue.crud.CRUDFindResponse;
 import com.redhat.lightblue.crud.CRUDInsertionResponse;
+import com.redhat.lightblue.crud.CrudConstants;
+import com.redhat.lightblue.crud.DocCtx;
+import com.redhat.lightblue.crud.Factory;
 import com.redhat.lightblue.crud.FindRequest;
 import com.redhat.lightblue.crud.InsertionRequest;
+import com.redhat.lightblue.crud.ListDocumentStream;
 import com.redhat.lightblue.metadata.Metadata;
+import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.JsonUtils;
 
 public class BulkTest extends AbstractMediatorTest {
 
@@ -123,6 +128,71 @@ public class BulkTest extends AbstractMediatorTest {
         Assert.assertEquals(0, response.getDataErrors().size());
         Assert.assertEquals(1, response.getErrors().size());
         Assert.assertEquals(CrudConstants.ERR_NO_ACCESS, response.getErrors().get(0).getErrorCode());
+    }
+
+    @Test
+    public void bulkResultSetTooLargeTest() throws Exception {
+        final JsonNode sampleDoc = loadJsonNode("./sample1.json");
+        mdManager.md.getAccess().getFind().setRoles("anyone");
+
+        BulkRequest breq = new BulkRequest();
+
+        InsertionRequest ireq = new InsertionRequest();
+        ireq.setEntityVersion(new EntityVersion("test", "1.0"));
+        ireq.setEntityData(sampleDoc);
+        ireq.setReturnFields(null);
+        ireq.setClientId(new RestClientIdentification(Arrays.asList("test-insert", "test-update")));
+        breq.add(ireq);
+
+        FindRequest freq = new FindRequest();
+        freq.setEntityVersion(new EntityVersion("test", "1.0"));
+        breq.add(freq);
+        mockCrudController.insertResponse=new CRUDInsertionResponse();
+        mockCrudController.insertResponse.setNumInserted(10);
+        mockCrudController.insertCb=ctx->{
+            ArrayList<DocCtx> docs=new ArrayList<>();
+            for(int i=0;i<10;i++) {
+                docs.add(new DocCtx(new JsonDoc(sampleDoc), new ResultMetadata()));
+            }
+            ctx.setDocumentStream(new ListDocumentStream<DocCtx>(docs));
+        };
+        mockCrudController.findResponse=new CRUDFindResponse();
+        mockCrudController.findResponse.setSize(10);
+        mockCrudController.findCb=ctx->{
+            ArrayList<DocCtx> docs=new ArrayList<>();
+            for(int i=0;i<10;i++) {
+                docs.add(new DocCtx(new JsonDoc(sampleDoc), new ResultMetadata()));
+            }
+            ctx.setDocumentStream(new ListDocumentStream<DocCtx>(docs));
+        };
+
+        mediator.factory.setWarnResultSetSizeB(10);
+
+        BulkResponse bresp = mediator.bulkRequest(breq);
+        Assert.assertEquals(2, breq.getEntries().size());
+
+        Response responseInsert = bresp.getEntries().get(0);
+        Response responseFind = bresp.getEntries().get(1);
+
+        Assert.assertEquals("Insert response should return 1262B of data", 1262, responseInsert.getResponseDataSizeB());
+        Assert.assertEquals("Find response should return 12620B of data", 12620, responseFind.getResponseDataSizeB());
+
+        mediator.factory.setMaxResultSetSizeB(12630); // the limit is more than each request alone
+
+        bresp = mediator.bulkRequest(breq);
+
+        responseInsert = bresp.getEntries().get(0);
+        responseFind = bresp.getEntries().get(1);
+
+        Assert.assertTrue("The first request should have no errors", responseInsert.getErrors().isEmpty());
+        Assert.assertEquals("The first request should have returend all data", 1262, JsonUtils.size(responseInsert.getEntityData()));
+        Assert.assertEquals("The second request should error, as it exceeds the response size threshold", 1, responseFind.getErrors().size());
+        Assert.assertEquals(Response.ERR_RESULT_SIZE_TOO_LARGE, responseFind.getErrors().get(0).getErrorCode());
+        Assert.assertEquals("The second request contains no data", 0, responseFind.getEntityData().size());
+
+        // TODO: print the warning only when threshold is breached, don't print it later
+        // TODO: make those meta fields in response transient
+        // TODO: don't print the error twice (Error.get also does it)
     }
 
     @Test

--- a/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
@@ -190,7 +190,6 @@ public class BulkTest extends AbstractMediatorTest {
         Assert.assertEquals(Response.ERR_RESULT_SIZE_TOO_LARGE, responseFind.getErrors().get(0).getErrorCode());
         Assert.assertEquals("The second request contains no data", 0, responseFind.getEntityData().size());
 
-        // TODO: print the warning only when threshold is breached, don't print it later
         // TODO: make those meta fields in response transient
         // TODO: don't print the error twice (Error.get also does it)
     }

--- a/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
@@ -18,10 +18,8 @@
  */
 package com.redhat.lightblue.mediator;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -40,22 +38,21 @@ import com.redhat.lightblue.crud.CRUDSaveResponse;
 import com.redhat.lightblue.crud.CRUDUpdateResponse;
 import com.redhat.lightblue.crud.CrudConstants;
 import com.redhat.lightblue.crud.DeleteRequest;
+import com.redhat.lightblue.crud.DocCtx;
 import com.redhat.lightblue.crud.FindRequest;
 import com.redhat.lightblue.crud.InsertionRequest;
+import com.redhat.lightblue.crud.ListDocumentStream;
 import com.redhat.lightblue.crud.SaveRequest;
 import com.redhat.lightblue.crud.UpdateRequest;
-import com.redhat.lightblue.crud.WithRange;
-import com.redhat.lightblue.crud.DocCtx;
-import com.redhat.lightblue.crud.ListDocumentStream;
 import com.redhat.lightblue.metadata.MetadataStatus;
 import com.redhat.lightblue.query.BinaryComparisonOperator;
 import com.redhat.lightblue.query.FieldProjection;
 import com.redhat.lightblue.query.Value;
 import com.redhat.lightblue.query.ValueComparisonExpression;
+import com.redhat.lightblue.util.Error;
 import com.redhat.lightblue.util.JsonDoc;
 import com.redhat.lightblue.util.JsonUtils;
 import com.redhat.lightblue.util.Path;
-import com.redhat.lightblue.util.Error;
 
 public class MediatorTest extends AbstractMediatorTest {
 

--- a/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
@@ -418,6 +418,7 @@ public class MediatorTest extends AbstractMediatorTest {
             ctx.setDocumentStream(new ListDocumentStream<DocCtx>(docs));
         };
 
+        mediator.factory.setWarnResultSetSizeB(600);
         mediator.factory.setMaxResultSetSizeB(-1);
         Response response = mediator.find(req); // no max result set size
         Assert.assertEquals("Expecting entity data size = 11290B", 11290, JsonUtils.size(response.getEntityData()));

--- a/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
@@ -18,6 +18,7 @@
  */
 package com.redhat.lightblue.mediator;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +53,7 @@ import com.redhat.lightblue.query.FieldProjection;
 import com.redhat.lightblue.query.Value;
 import com.redhat.lightblue.query.ValueComparisonExpression;
 import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.JsonUtils;
 import com.redhat.lightblue.util.Path;
 import com.redhat.lightblue.util.Error;
 
@@ -398,6 +400,43 @@ public class MediatorTest extends AbstractMediatorTest {
         Assert.assertEquals(OperationStatus.ERROR, response.getStatus());
         Assert.assertEquals(1,response.getErrors().size());
         Assert.assertEquals(CrudConstants.ERR_DATASOURCE_TIMEOUT,response.getErrors().get(0).getErrorCode());
+    }
+
+    @Test
+    public void findResultSetTooLargeTest() throws Exception {
+
+        final JsonNode sampleDoc = loadJsonNode("./sample1.json");
+
+        FindRequest req = new FindRequest();
+        req.setEntityVersion(new EntityVersion("test", "1.0"));
+
+        mdManager.md.getAccess().getFind().setRoles("anyone");
+        mockCrudController.findResponse = new CRUDFindResponse();
+        mockCrudController.findResponse.setSize(10);
+        mockCrudController.findCb=ctx->{
+            ArrayList<DocCtx> docs=new ArrayList<>();
+            for(int i=0;i<10;i++) {
+                docs.add(new DocCtx(new JsonDoc(sampleDoc),getRmd(Integer.toString(i))));
+            }
+            ctx.setDocumentStream(new ListDocumentStream<DocCtx>(docs));
+        };
+
+        mediator.factory.setMaxResultSetSizeB(-1);
+        Response response = mediator.find(req); // no max result set size
+        Assert.assertEquals("Expecting entity data size = 11290B", 11290, JsonUtils.size(response.getEntityData()));
+        Assert.assertTrue("Expecting no errors in response", response.getErrors().isEmpty());
+
+        mediator.factory.setMaxResultSetSizeB(12000);
+        response = mediator.find(req); // max result set size set, but response below threshold
+        Assert.assertEquals("Expecting entity data size = 11290B", 11290, JsonUtils.size(response.getEntityData()));
+        Assert.assertTrue("Expecting no errors in response", response.getErrors().isEmpty());
+
+        mediator.factory.setMaxResultSetSizeB(11000);
+        response = mediator.find(req); // max result set size exceeded
+        Assert.assertEquals("Expecting entity data size = 0", 0, JsonUtils.size(response.getEntityData()));
+        Assert.assertEquals("Expecting one error in response", 1, response.getErrors().size());
+        Assert.assertEquals("crud:ResultSizeTooLarge", response.getErrors().get(0).getErrorCode());
+        Assert.assertEquals("11290B > 11000B", response.getErrors().get(0).getMsg());
     }
 
     @Test


### PR DESCRIPTION
Adding logic to Mediator#find which checks the size of results list as it's being populated from a stream. If the size of that list exceeds a configured threshold, client receives crud:ResultSizeTooLarge error and no data. This is to prevent OoM errors when large documents are being returned.

It's also possible to define a warning threshold for result set size. It differs from StopWatch annotation in that it will log a warning even when Mediator#find does not return (e.g. system error, or node restarted because of OoM).