### PR TITLE
Adding MemoryMonitor to enforce memory limits

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/CrudConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/config/CrudConfiguration.java
@@ -49,7 +49,8 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
     private boolean validateRequests = false;
     private int bulkParallelExecutions = 3;
     private int memoryIndexThreshold = 16;
-    private int maxResultSetSizeB = 50 * 1024 * 1024; // 50 MB
+    private int maxResultSetSizeForReadsB = 50 * 1024 * 1024; // 50 MB
+    private int maxResultSetSizeForWritesB = 50 * 1024 * 1024; // 50 MB
     private int warnResultSetSizeB = 10 * 1024 * 1024; // 10 MB
 
     public boolean isValidateRequests() {
@@ -138,14 +139,19 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
                 memoryIndexThreshold = x.intValue();
             }
 
-            x = node.get("maxResultSetSizeB");
+            x = node.get("maxResultSetSizeForReadsB");
             if (x != null) {
-                maxResultSetSizeB = x.intValue();
+                maxResultSetSizeForReadsB = x.intValue();
             }
 
             x = node.get("warnResultSetSizeB");
             if (x != null) {
                 warnResultSetSizeB = x.intValue();
+            }
+
+            x = node.get("maxResultSetSizeForWritesB");
+            if (x != null) {
+                maxResultSetSizeForWritesB = x.intValue();
             }
         }
     }
@@ -158,12 +164,12 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
         this.memoryIndexThreshold = memoryIndexThreshold;
     }
 
-    public int getMaxResultSetSizeB() {
-        return maxResultSetSizeB;
+    public int getMaxResultSetSizeForReadsB() {
+        return maxResultSetSizeForReadsB;
     }
 
-    public void setMaxResultSetSizeB(int maxResultSetSizeB) {
-        this.maxResultSetSizeB = maxResultSetSizeB;
+    public void setMaxResultSetSizeForReadsB(int maxResultSetSizeB) {
+        this.maxResultSetSizeForReadsB = maxResultSetSizeB;
     }
 
     public int getWarnResultSetSizeB() {
@@ -172,5 +178,13 @@ public class CrudConfiguration implements JsonInitializable, Serializable {
 
     public void setWarnResultSetSizeB(int warnResultSetSizeB) {
         this.warnResultSetSizeB = warnResultSetSizeB;
+    }
+
+    public int getMaxResultSetSizeForWritesB() {
+        return maxResultSetSizeForWritesB;
+    }
+
+    public void setMaxResultSetSizeForWritesB(int maxResultSetSizeForWritesB) {
+        this.maxResultSetSizeForWritesB = maxResultSetSizeForWritesB;
     }
 }

--- a/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
+++ b/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
@@ -161,8 +161,9 @@ public final class LightblueFactory implements Serializable {
             f.setBulkParallelExecutions(crudConfiguration.getBulkParallelExecutions());
             f.setMemoryIndexThreshold(crudConfiguration.getMemoryIndexThreshold());
             f.addFieldConstraintValidators(new DefaultFieldConstraintValidators());
-            f.setMaxResultSetSizeB(crudConfiguration.getMaxResultSetSizeB());
+            f.setMaxResultSetSizeForReadsB(crudConfiguration.getMaxResultSetSizeForReadsB());
             f.setWarnResultSetSizeB(crudConfiguration.getWarnResultSetSizeB());
+            f.setMaxResultSetSizeForWritesB(crudConfiguration.getMaxResultSetSizeForWritesB());
 
             // Add default interceptors
             new UIDInterceptor().register(f.getInterceptors());

--- a/crud/src/main/java/com/redhat/lightblue/crud/Factory.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/Factory.java
@@ -62,8 +62,9 @@ public class Factory implements Serializable {
     private JsonNodeFactory nodeFactory;
     private int bulkParallelExecutions = 3;
     private int memoryIndexThreshold = 16;
-    private int maxResultSetSizeB;
+    private int maxResultSetSizeForReadsB;
     private int warnResultSetSizeB;
+    private int maxResultSetSizeForWritesB;
 
     /**
      * Adds a field constraint validator
@@ -230,12 +231,12 @@ public class Factory implements Serializable {
         this.memoryIndexThreshold = memoryIndexThreshold;
     }
 
-    public int getMaxResultSetSizeB() {
-        return maxResultSetSizeB;
+    public int getMaxResultSetSizeForReadsB() {
+        return maxResultSetSizeForReadsB;
     }
 
-    public void setMaxResultSetSizeB(int maxResultSetSizeB) {
-        this.maxResultSetSizeB = maxResultSetSizeB;
+    public void setMaxResultSetSizeForReadsB(int maxResultSetSizeB) {
+        this.maxResultSetSizeForReadsB = maxResultSetSizeB;
     }
 
     public int getWarnResultSetSizeB() {
@@ -246,12 +247,20 @@ public class Factory implements Serializable {
         this.warnResultSetSizeB = warnResultSetSizeB;
     }
 
+    public int getMaxResultSetSizeForWritesB() {
+       return maxResultSetSizeForWritesB;
+    }
+
+    public void setMaxResultSetSizeForWritesB(int maxResultSetSizeForWritesB) {
+        this.maxResultSetSizeForWritesB = maxResultSetSizeForWritesB;
+    }
+
     @Override
     public String toString() {
         return "Factory [fieldConstraintValidatorRegistry=" + fieldConstraintValidatorRegistry + ", entityConstraintValidatorRegistry="
                 + entityConstraintValidatorRegistry + ", crudControllers=" + crudControllers + ", hookResolver=" + hookResolver + ", interceptors="
                 + interceptors + ", generators=" + generators + ", nodeFactory=" + nodeFactory + ", bulkParallelExecutions=" + bulkParallelExecutions
-                + ", memoryIndexThreshold=" + memoryIndexThreshold + ", maxResultSetSizeB=" + maxResultSetSizeB + ", warnResultSetSizeB=" + warnResultSetSizeB
-                + "]";
+                + ", memoryIndexThreshold=" + memoryIndexThreshold + ", maxResultSetSizeForReadsB=" + maxResultSetSizeForReadsB + ", warnResultSetSizeB="
+                + warnResultSetSizeB + ", maxResultSetSizeForWritesB=" + maxResultSetSizeForWritesB + "]";
     }
 }

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -490,7 +490,7 @@ public class Mediator {
                 DocumentStream<DocCtx> docStream=r.documentStream;
                 List<ResultMetadata> rmd=new ArrayList<>();
                 response.setEntityData(factory.getNodeFactory().arrayNode());
-                response.setResultSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
+                response.setResultSizeThresholds(factory.getMaxResultSetSizeForReadsB(), factory.getWarnResultSetSizeB(), req);
 
                 for(;docStream.hasNext();) {
                     DocCtx doc=docStream.next();
@@ -693,7 +693,7 @@ public class Mediator {
             List<Request> requestList = requests.getEntries();
             int n = requestList.size();
             BulkExecutionContext ctx = new BulkExecutionContext(n);
-            ctx.setResultSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), requests);
+            ctx.setResultSizeThresholds(factory.getMaxResultSetSizeForReadsB(), factory.getWarnResultSetSizeB(), requests);
 
             for (int i = 0; i < n; i++) {
                 Request req = requestList.get(i);
@@ -837,7 +837,7 @@ public class Mediator {
             if (ctx.getHookManager().isHookQueueEmpty()) {
                 // ensure response size only if hooks didn't fire
                 // otherwise result stream is read during hook queuing and this is where those checks take place
-                response.setResultSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
+                response.setResultSizeThresholds(factory.getMaxResultSetSizeForWritesB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
             }
 
             for(;docStream.hasNext();) {

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -136,7 +136,6 @@ public class Mediator {
                 if (!ctx.hasErrors() && ctx.hasInputDocumentsWithoutErrors()) {
                     LOGGER.debug(CRUD_MSG_PREFIX, controller.getClass().getName());
                     CRUDInsertionResponse ir=controller.insert(ctx, req.getReturnFields());
-                    ctx.getHookManager().setQueuedHooksSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
                     ctx.getHookManager().queueMediatorHooks(ctx);
                     ctx.measure.begin("postProcessInsertedDocs");
                     response.setModifiedCount(ir.getNumInserted());
@@ -301,7 +300,6 @@ public class Mediator {
                         updateResponse.setNumMatched(0);
                     }
                 }
-                ctx.getHookManager().setQueuedHooksSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
                 ctx.getHookManager().queueMediatorHooks(ctx);
                 ctx.measure.begin("postProcessUpdatedDocs");
                 LOGGER.debug("# Updated", updateResponse.getNumUpdated());                
@@ -373,7 +371,6 @@ public class Mediator {
                     }
                 }
 
-                ctx.getHookManager().setQueuedHooksSizeThresholds(factory.getMaxResultSetSizeB(), factory.getWarnResultSetSizeB(), req);
                 ctx.getHookManager().queueMediatorHooks(ctx);
                 response.setModifiedCount(result == null ? 0 : result.getNumDeleted());
                 if (ctx.hasErrors()) {

--- a/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/BulkTest.java
@@ -177,7 +177,7 @@ public class BulkTest extends AbstractMediatorTest {
         Assert.assertEquals("Insert response should return 1262B of data", 1262, responseInsert.getResponseDataSizeB());
         Assert.assertEquals("Find response should return 12620B of data", 12620, responseFind.getResponseDataSizeB());
 
-        mediator.factory.setMaxResultSetSizeB(12630); // the limit is more than each request alone
+        mediator.factory.setMaxResultSetSizeForReadsB(12630); // the limit is more than each request alone
 
         bresp = mediator.bulkRequest(breq);
 

--- a/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/mediator/MediatorTest.java
@@ -185,7 +185,6 @@ public class MediatorTest extends AbstractMediatorTest {
         Assert.assertEquals(0, response.getMatchCount());
         Assert.assertEquals(0, response.getDataErrors().size());
         Assert.assertEquals(0, response.getErrors().size());
-
     }
 
     @Test
@@ -419,17 +418,17 @@ public class MediatorTest extends AbstractMediatorTest {
         };
 
         mediator.factory.setWarnResultSetSizeB(600);
-        mediator.factory.setMaxResultSetSizeB(-1);
+        mediator.factory.setMaxResultSetSizeForReadsB(-1);
         Response response = mediator.find(req); // no max result set size
         Assert.assertEquals("Expecting entity data size = 11290B", 11290, JsonUtils.size(response.getEntityData()));
         Assert.assertTrue("Expecting no errors in response", response.getErrors().isEmpty());
 
-        mediator.factory.setMaxResultSetSizeB(12000);
+        mediator.factory.setMaxResultSetSizeForReadsB(12000);
         response = mediator.find(req); // max result set size set, but response below threshold
         Assert.assertEquals("Expecting entity data size = 11290B", 11290, JsonUtils.size(response.getEntityData()));
         Assert.assertTrue("Expecting no errors in response", response.getErrors().isEmpty());
 
-        mediator.factory.setMaxResultSetSizeB(11000);
+        mediator.factory.setMaxResultSetSizeForReadsB(11000);
         response = mediator.find(req); // max result set size exceeded
         Assert.assertEquals("Expecting entity data size = 0", 0, JsonUtils.size(response.getEntityData()));
         Assert.assertEquals("Expecting one error in response", 1, response.getErrors().size());
@@ -456,7 +455,7 @@ public class MediatorTest extends AbstractMediatorTest {
         };
 
 
-        mediator.factory.setMaxResultSetSizeB(11000);
+        mediator.factory.setMaxResultSetSizeForWritesB(11000);
         Response response = mediator.update(req); // max result set size exceeded
         Assert.assertEquals("Expecting entity data size = 0", 0, JsonUtils.size(response.getEntityData()));
         Assert.assertEquals("Expecting one error in response", 1, response.getErrors().size());

--- a/util/src/main/java/com/redhat/lightblue/util/MemoryMonitor.java
+++ b/util/src/main/java/com/redhat/lightblue/util/MemoryMonitor.java
@@ -1,0 +1,85 @@
+package com.redhat.lightblue.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for tracking memory usage for given type (assuming it's an immutable value).
+ * You can set thresholds and have it execute callbacks when they are exceeded. See {@link MemoryMonitorTest} for usage.
+ *
+ * @author mpatercz
+ *
+ * @param <T>
+ */
+public class MemoryMonitor<T> {
+
+    @FunctionalInterface
+    public static interface SizeCalculator<T> {
+        public int size(T obj);
+    }
+
+    @FunctionalInterface
+    public static interface ThresholdExceededCallback<T> {
+        public void fire(int currentSizeB, int thresholdB, T obj) throws RuntimeException;
+    }
+
+    public static class ThresholdMonitor<T> {
+
+        final int thresholdB;
+
+        boolean fired = false;
+
+        final ThresholdExceededCallback<T> event;
+
+        public ThresholdMonitor(int thresholdB, ThresholdExceededCallback<T> event) {
+            super();
+            this.thresholdB = thresholdB;
+            this.event = event;
+        }
+
+    }
+
+    private int dataSizeB = 0;
+
+    private SizeCalculator<T> sizeCalculator;
+
+    private List<ThresholdMonitor<T>> monitors = new ArrayList<>();
+
+    public void registerMonitor(ThresholdMonitor<T> m) {
+        if (m.thresholdB > 0) {
+            this.monitors.add(m);
+        }
+    }
+
+    private void checkThresholdMonitors(T obj) throws RuntimeException {
+        for (ThresholdMonitor<T> m: monitors) {
+            if (dataSizeB > m.thresholdB && !m.fired) {
+                m.fired = true;
+                m.event.fire(dataSizeB, m.thresholdB, obj);
+            }
+        }
+    }
+
+    public MemoryMonitor(SizeCalculator<T> sizeCalculator) {
+        super();
+        this.sizeCalculator = sizeCalculator;
+    }
+
+    /**
+     * Add this value's size to the total.
+     *
+     * @param value
+     * @return
+     */
+    public T apply(final T value) {
+        dataSizeB += sizeCalculator.size(value);
+
+        checkThresholdMonitors(value);
+
+        return value;
+    }
+
+    public int getDataSizeB() {
+        return dataSizeB;
+    }
+}

--- a/util/src/main/java/com/redhat/lightblue/util/MemoryMonitor.java
+++ b/util/src/main/java/com/redhat/lightblue/util/MemoryMonitor.java
@@ -29,12 +29,12 @@ public class MemoryMonitor<T> {
 
         boolean fired = false;
 
-        final ThresholdExceededCallback<T> event;
+        final ThresholdExceededCallback<T> callback;
 
-        public ThresholdMonitor(int thresholdB, ThresholdExceededCallback<T> event) {
+        public ThresholdMonitor(int thresholdB, ThresholdExceededCallback<T> callback) {
             super();
             this.thresholdB = thresholdB;
-            this.event = event;
+            this.callback = callback;
         }
 
     }
@@ -45,6 +45,13 @@ public class MemoryMonitor<T> {
 
     private List<ThresholdMonitor<T>> monitors = new ArrayList<>();
 
+    /**
+     * Adds a monitor with a callback which fires when specified threshold is exceeded. The callback will fire only once.
+     *
+     * Monitors/callbacks are processed in order they were registered. If a callback throws a RuntimeException, processing stops.
+     *
+     * @param m
+     */
     public void registerMonitor(ThresholdMonitor<T> m) {
         if (m.thresholdB > 0) {
             this.monitors.add(m);
@@ -55,7 +62,7 @@ public class MemoryMonitor<T> {
         for (ThresholdMonitor<T> m: monitors) {
             if (dataSizeB > m.thresholdB && !m.fired) {
                 m.fired = true;
-                m.event.fire(dataSizeB, m.thresholdB, obj);
+                m.callback.fire(dataSizeB, m.thresholdB, obj);
             }
         }
     }

--- a/util/src/test/java/com/redhat/lightblue/util/MemoryMonitorTest.java
+++ b/util/src/test/java/com/redhat/lightblue/util/MemoryMonitorTest.java
@@ -1,0 +1,66 @@
+package com.redhat.lightblue.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.redhat.lightblue.util.MemoryMonitor.ThresholdMonitor;
+
+
+public class MemoryMonitorTest {
+
+    @Test
+    public void testSizeGrowing() {
+
+        String el1 = "foobar";
+        String el2 = "foo";
+        String el3 = "bar";
+
+        MemoryMonitor<String> m = new MemoryMonitor<>( (el) ->  el.length());
+
+        Assert.assertEquals(0, m.getDataSizeB());
+        m.apply(el1);
+        Assert.assertEquals(el1.length(), m.getDataSizeB());
+        m.apply(el2);
+        Assert.assertEquals(el1.length()+el2.length(), m.getDataSizeB());
+        m.apply(el3);
+        Assert.assertEquals(el1.length()+el2.length()+el3.length(), m.getDataSizeB());
+
+    }
+
+    @Test
+    public void testThresholds() {
+
+        String el1 = "foobar";
+        String el2 = "foo";
+        String el3 = "bar";
+
+        MemoryMonitor<String> list = new MemoryMonitor<>( (el) ->  el.length());
+
+        int fired[] = new int[2];
+        fired[0] = 0;
+        fired[1] = 0;
+
+        list.registerMonitor(new ThresholdMonitor<String>(el1.length()-1, (size, threshold, str) ->{
+            fired[0] += 1;
+        }));
+
+        list.registerMonitor(new ThresholdMonitor<String>(el1.length()+el2.length()+1, (size, threshold, str) ->{
+            fired[1] += 1;
+        }));
+
+        Assert.assertTrue(fired[0]==0 && fired[1]==0);
+
+        list.apply(el1);
+
+        Assert.assertTrue(fired[0]==1 && fired[1]==0);
+
+        list.apply(el2);
+
+        Assert.assertTrue(fired[0]==1 && fired[1]==0);
+
+        list.apply(el3);
+
+        Assert.assertTrue(fired[0]==1 && fired[1]==1);
+    }
+
+}


### PR DESCRIPTION
The limits need to be enforced in multiple locations: Response, BulkExecutionContext, HookManager and IterateAndUpdate (last one from lightblue-mongo). To avoid logic redundancy, creating MemoryMonitor utility.

Note that Mediator level hooks are not used (https://github.com/lightblue-platform/lightblue-core/issues/804).