### PR TITLE
MemoryMonitor improvements

### DIFF
--- a/core-api/src/main/java/com/redhat/lightblue/Response.java
+++ b/core-api/src/main/java/com/redhat/lightblue/Response.java
@@ -84,10 +84,6 @@ public class Response extends BaseResponse  {
     public void setResultSizeThresholds(int maxResultSetSizeB, int warnResultSetSizeB, final Request forRequest) {
         this.memoryMonitor = new MemoryMonitor<>((jsonNode) -> JsonUtils.size(jsonNode));
 
-        memoryMonitor.registerMonitor(new ThresholdMonitor<JsonNode>(warnResultSetSizeB, (current, threshold, doc) -> {
-            LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, current);
-        }));
-
         memoryMonitor.registerMonitor(new ThresholdMonitor<JsonNode>(maxResultSetSizeB, (current, threshold, doc) -> {
             // empty data
             // returning incomplete result set could be useful, but also confusing and thus dangerous
@@ -95,6 +91,11 @@ public class Response extends BaseResponse  {
             setEntityData(JsonNodeFactory.instance.arrayNode());
             throw Error.get(ERR_RESULT_SIZE_TOO_LARGE, current+"B > "+threshold+"B");
         }));
+
+        memoryMonitor.registerMonitor(new ThresholdMonitor<JsonNode>(warnResultSetSizeB, (current, threshold, doc) -> {
+            LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, current);
+        }));
+
     }
 
     /**

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -88,13 +88,14 @@ public class HookManager {
     public void setQueuedHooksSizeThresholds(int maxQueuedHooksSizeB, int warnQueuedHooksSizeB, final QueryExpression query, int initialDataSizeB) {
         this.monitor = new MemoryMonitor<>((node) -> JsonUtils.size(node), initialDataSizeB);
 
+        this.monitor.registerMonitor(new ThresholdMonitor<>(maxQueuedHooksSizeB, (current, threshold, node) -> {
+            throw Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, current+"B > "+threshold+"B (during hook processing)");
+        }));
+
         this.monitor.registerMonitor(new ThresholdMonitor<>(warnQueuedHooksSizeB, (current, threshold, node) -> {
             LOGGER.warn("crud:ResultSizeIsLarge: query={}, queuedHooksSizeB={}", query, current);
         }));
 
-        this.monitor.registerMonitor(new ThresholdMonitor<>(maxQueuedHooksSizeB, (current, threshold, node) -> {
-            throw Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, current+"B > "+threshold+"B (during hook processing)");
-        }));
     }
 
     private static final class HookDocInfo {

--- a/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
+++ b/crud/src/main/java/com/redhat/lightblue/hooks/HookManager.java
@@ -83,9 +83,10 @@ public class HookManager {
      * @param maxResultSetSizeB error when this threshold is breached
      * @param warnResultSetSizeB log a warning when this threshold is breached
      * @param forRequest request which resulted in this response, for logging purposes
+     * @param initialDataSizeB initial size in memory (memory occupied by prior operations)
      */
-    public void setQueuedHooksSizeThresholds(int maxQueuedHooksSizeB, int warnQueuedHooksSizeB, final QueryExpression query) {
-        this.monitor = new MemoryMonitor<>((node) -> JsonUtils.size(node));
+    public void setQueuedHooksSizeThresholds(int maxQueuedHooksSizeB, int warnQueuedHooksSizeB, final QueryExpression query, int initialDataSizeB) {
+        this.monitor = new MemoryMonitor<>((node) -> JsonUtils.size(node), initialDataSizeB);
 
         this.monitor.registerMonitor(new ThresholdMonitor<>(warnQueuedHooksSizeB, (current, threshold, node) -> {
             LOGGER.warn("crud:ResultSizeIsLarge: query={}, queuedHooksSizeB={}", query, current);

--- a/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/BulkExecutionContext.java
@@ -39,15 +39,16 @@ public class BulkExecutionContext {
 
         this.memoryMonitor = new MemoryMonitor<>((response) -> response.getResponseDataSizeB());
 
-        memoryMonitor.registerMonitor(new ThresholdMonitor<Response>(warnResultSetSizeB, (current, threshold, response) -> {
-            LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, current);
-        }));
-
         memoryMonitor.registerMonitor(new ThresholdMonitor<Response>(maxResultSetSizeB, (current, threshold, response) -> {
             // remove data
             response.setEntityData(JsonNodeFactory.instance.arrayNode());
             response.getErrors().add(Error.get(Response.ERR_RESULT_SIZE_TOO_LARGE, current+"B > "+threshold+"B"));
         }));
+
+        memoryMonitor.registerMonitor(new ThresholdMonitor<Response>(warnResultSetSizeB, (current, threshold, response) -> {
+            LOGGER.warn("crud:ResultSizeIsLarge: request={}, responseDataSizeB={}", forRequest, current);
+        }));
+
     }
 
     /**

--- a/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
+++ b/crud/src/main/java/com/redhat/lightblue/mediator/Mediator.java
@@ -834,11 +834,9 @@ public class Mediator {
         if(docStream!=null) {
             List<ResultMetadata> rmd=new ArrayList<>();
 
-            if (ctx.getHookManager().isHookQueueEmpty()) {
-                // ensure response size only if hooks didn't fire
-                // otherwise result stream is read during hook queuing and this is where those checks take place
-                response.setResultSizeThresholds(factory.getMaxResultSetSizeForWritesB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
-            }
+            // this is somewhat redundant, as update memory limits are enforced in mongo controller
+            // but we want to have the response size in case this is a bulk request and we will aggregate response sizes
+            response.setResultSizeThresholds(factory.getMaxResultSetSizeForWritesB(), factory.getWarnResultSetSizeB(), (Request)requestWithRange);
 
             for(;docStream.hasNext();) {
                 DocCtx doc=docStream.next();

--- a/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/hooks/HookManagerTest.java
@@ -315,14 +315,14 @@ public class HookManagerTest extends AbstractJsonNodeTest {
                     JsonUtils.size(doc.getUpdatedDocument().getRoot()));  // post copy
         }
 
-        hooks.setQueuedHooksSizeThresholds(expectedSizeB+10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB+10, 1, null, 0);
 
         // queue hooks (process entire stream of results)
         hooks.queueHooks(ctx);
 
         Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
 
-        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null, 0);
 
         try {
             hooks.queueHooks(ctx);
@@ -346,14 +346,14 @@ public class HookManagerTest extends AbstractJsonNodeTest {
                     JsonUtils.size(doc.getRoot())); // post copy
         }
 
-        hooks.setQueuedHooksSizeThresholds(-1, 1, null);
+        hooks.setQueuedHooksSizeThresholds(-1, 1, null, 0);
 
         // queue hooks (process entire stream of results)
         hooks.queueHooks(ctx);
 
         Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
 
-        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null, 0);
 
         try {
             hooks.queueHooks(ctx);
@@ -377,14 +377,14 @@ public class HookManagerTest extends AbstractJsonNodeTest {
                     JsonUtils.size(doc.getRoot())); // pre copy
         }
 
-        hooks.setQueuedHooksSizeThresholds(-1, 1, null);
+        hooks.setQueuedHooksSizeThresholds(-1, 1, null, 0);
 
         // queue hooks (process entire stream of results)
         hooks.queueHooks(ctx);
 
         Assert.assertEquals(expectedSizeB, hooks.getQueuedHooksSizeB());
 
-        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null);
+        hooks.setQueuedHooksSizeThresholds(expectedSizeB-10, 1, null, 0);
 
         try {
             hooks.queueHooks(ctx);

--- a/util/src/main/java/com/redhat/lightblue/util/MemoryMonitor.java
+++ b/util/src/main/java/com/redhat/lightblue/util/MemoryMonitor.java
@@ -67,9 +67,14 @@ public class MemoryMonitor<T> {
         }
     }
 
-    public MemoryMonitor(SizeCalculator<T> sizeCalculator) {
+    public MemoryMonitor(SizeCalculator<T> sizeCalculator, int intialDataSizeB) {
         super();
         this.sizeCalculator = sizeCalculator;
+        this.dataSizeB = intialDataSizeB;
+    }
+
+    public MemoryMonitor(SizeCalculator<T> sizeCalculator) {
+        this(sizeCalculator, 0);
     }
 
     /**


### PR DESCRIPTION
* Moving maxResultSetSize monitor above warn one to ensure that max always fires when needed
* Always check the size of a write Response in case this is a bulk operation
* Adding intialDataSizeB to memory monitor to be able to stack memory monitors
