### PR TITLE
A flexible way to initialize ControllerFactory

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
+++ b/config/src/main/java/com/redhat/lightblue/config/LightblueFactory.java
@@ -182,7 +182,7 @@ public final class LightblueFactory implements Serializable {
             new GeneratedFieldInterceptor().register(f.getInterceptors());
 
             for (ControllerConfiguration x : crudConfiguration.getControllers()) {
-                ControllerFactory cfactory = x.getControllerFactory().newInstance();
+                ControllerFactory cfactory = x.getControllerFactoryInitializer().newInstance();
                 CRUDController controller = cfactory.createController(x, datasources);
                 injectDependencies(controller);
                 f.addCRUDController(x.getBackend(), controller);


### PR DESCRIPTION
This change is to allow parametrization of ControllerFactory. Not sure if it has to be initialized lazily, but keeping existing behavior.

The use case I have in mind is passing MongoClient to Lightblue, as opposed to letting Lightblue initialize it itself. Helpful when MongoClient is managed by other means (e.g. spring).