### PR TITLE
this fixes an issue where the incorrect version of json-validator-core is being pulled in

### DIFF
--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -61,10 +61,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -47,11 +47,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -131,12 +131,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
                 <scope>compile</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.fge</groupId>
-                <artifactId>json-schema-core</artifactId>
-                <version>1.2.4</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>20090211</version>

--- a/query-api/pom.xml
+++ b/query-api/pom.xml
@@ -37,10 +37,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -61,10 +61,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
         </dependency>


### PR DESCRIPTION
Fixes this runtime error I got because of a dependency tree conflict between lightblue-core-config and lightblue-core-crud.

```
Caused by: java.lang.NoClassDefFoundError: Could not initialize class com.github.fge.jsonschema.SchemaVersion
	at com.github.fge.jsonschema.core.load.configuration.LoadingConfigurationBuilder.<init>(LoadingConfigurationBuilder.java:117)
	at com.github.fge.jsonschema.core.load.configuration.LoadingConfiguration.byDefault(LoadingConfiguration.java:151)
	at com.github.fge.jsonschema.main.JsonSchemaFactoryBuilder.<init>(JsonSchemaFactoryBuilder.java:67)
	at com.github.fge.jsonschema.main.JsonSchemaFactory.newBuilder(JsonSchemaFactory.java:123)
	at com.github.fge.jsonschema.main.JsonSchemaFactory.byDefault(JsonSchemaFactory.java:113)
	at com.redhat.lightblue.util.JsonUtils.loadSchema(JsonUtils.java:281)
	at com.redhat.lightblue.config.JsonTranslator.registerTranslation(JsonTranslator.java:133)
	at com.redhat.lightblue.config.LightblueFactory.initializeJsonTranslator(LightblueFactory.java:250)
	at com.redhat.lightblue.config.LightblueFactory.getJsonTranslator(LightblueFactory.java:400)
	at com.redhat.lightblue.config.LightblueFactory.initializeFactory(LightblueFactory.java:170)
	at com.redhat.lightblue.config.LightblueFactory.getFactory(LightblueFactory.java:365)
	at com.redhat.lightblue.config.LightblueFactory.getMetadata(LightblueFactory.java:344)
```